### PR TITLE
Add contributors + ORCID, refresh README and AGENTS docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,76 +5,55 @@ Never "just edit labels". Treat every change as a semantic change unless proven 
 
 ## Prime directive
 - Do not change meaning silently.
+- Do not invent or rename ontology terms. If labels/definitions are missing, list them; do not fabricate.
 - If you cannot justify a change with the ontology's modeling patterns and scope, stop and propose alternatives.
 
 ## Repo map (authoritative paths)
-- Source ontology modules: `ontology/` (`hcm.ttl`, `hcm-align.ttl`, `hcm-metadata.ttl`)
+- Release manifest (the contract downstream tools read): `hcmo.yaml` — its **shape is an API**; keep it stable.
+- Hand-authored ontology source modules: `ontology/modules/*.ttl` (`hcm-core`, `hcm-bio`, `hcm-env`, `hcm-obs`).
 - JSON-LD context: `ontology/context.jsonld`
-- Imports: declared in `ontology/hcm-metadata.ttl` (no separate imports folder)
-- Releases / exports: none in repo (do not add generated artifacts without instruction)
+- Generated artifacts (**never hand-edit**): `dist/` (`hcmo.ttl` merged/canonical, `hcmo.owl`, `hcmo.json`, `profile.json`).
 - Shapes / constraints: `shapes/`
-- Competency questions / examples: `examples/`
-- Queries: `queries/`
-- Docs: `docs/`
+- Examples (ABox): `examples/`
+- Queries + competency-question index: `queries/` (`competency_questions.yaml`, `cq-*.rq`)
+- Tooling: `tooling/build.py` (regenerate dist), `tooling/validate.py` (CI gate).
+- Docs: `docs/` (incl. `docs/MISSING-DEFINITIONS.md`).
+- Previous ontology (HCMO 1.0.0, retained not deleted): `ontology/legacy/`.
 
-If these paths change, update this map in your plan before editing.
+If these paths change, update this map and `hcmo.yaml` before editing.
+
+## Namespace (authoritative)
+- Base namespace: `https://w3id.org/hcmo/ontology/hcm#`
+- Ontology IRI: `https://w3id.org/hcmo/ontology/hcm` · versionIRI `…/hcm/0.0.1`
+- Module sub-namespaces: `…/hcm/bio#`, `…/hcm/env#`, `…/hcm/obs#`
+- Never re-mint IRIs for existing concepts. Deprecate instead. Keep the namespace exactly as authored; if it must change, call it out and bump `owl:versionIRI`.
 
 ## Ontology style & best practices (non-negotiable)
-### Identifiers & IRIs
-- Every entity must have a stable IRI following the project pattern (no random hashes, no ad-hoc base IRIs).
-- Never re-mint IRIs for existing concepts. Deprecate instead.
-
 ### Labels, definitions, and annotations
-- Each class/property MUST have:
-  - rdfs:label (one preferred label per language)
-  - a textual definition (e.g., IAO:0000115 or equivalent)
-  - provenance note (source or rationale; lightweight is fine)
-- Synonyms must be typed (exact/broad/narrow/related) if your stack supports it.
-- Avoid "definition-by-example" and avoid circular definitions.
-
-### Modeling discipline
-- Use the canonical design patterns documented in `docs/MODEL.md`.
-- Prefer necessary & sufficient conditions ONLY when you can defend them under reasoning.
-- Use imports deliberately; never duplicate imported terms.
+- Each class/property SHOULD have an `rdfs:label`, a textual definition (`rdfs:comment` and/or `IAO:0000115`), and a lightweight provenance note.
+- Missing labels/definitions are tracked in `docs/MISSING-DEFINITIONS.md` — fill them at the source module; do not invent.
+- Avoid definition-by-example and circular definitions.
 
 ### Modularity
-- Changes must go into the correct ontology file (`ontology/hcm.ttl`, `ontology/hcm-align.ttl`, or `ontology/hcm-metadata.ttl`).
-- Keep the "core" minimal; push application-specific constraints to shapes or examples.
+- Put each term in the correct module by namespace (`hcm-core/bio/env/obs`).
+- Keep "core" minimal; push application-specific constraints to `shapes/` or `examples/`.
+- `dist/` is always regenerated from modules — never edit it by hand.
 
 ## Quality gates (must pass before you declare "done")
-Minimum gates:
-1) Syntax/parse check for all ontology sources
-2) Reasoning check: no unsatisfiable classes introduced
-3) Report of changed entities (diff)
-4) Linting/annotation completeness (labels + definitions coverage)
-
-Run the repo's existing validation script first:
-- `./tooling/validate.ps1`
-
-If a reasoner or lint step is not available locally, propose a minimal CI addition
-(ROBOT verify/report/reason or equivalent) before declaring completion.
+Run, in order, from the repo root:
+1. `python tooling/build.py` — regenerate `dist/` + `profile.json` (must be reproducible: re-running produces no diff).
+2. `python tooling/validate.py` — parses every TTL, runs pySHACL of `shapes/` against `examples/`, runs each `queries/cq-*.rq` against the merged graph; exits non-zero on failure.
+3. Commit `dist/` changes alongside the module changes (CI fails if `dist/` is stale).
 
 ## How to work (required process)
 When asked to change anything:
-1) Produce a short PLAN that includes:
-   - files/modules touched
-   - impacted terms
-   - expected semantic effect
-   - tests/commands you will run
-2) Implement the smallest correct change.
-3) Run quality gates.
-4) Summarize results + provide a PR-ready changelog entry.
+1. Produce a short PLAN: modules touched, impacted terms, expected semantic effect, commands to run.
+2. Implement the smallest correct change in `ontology/modules/`.
+3. Run the quality gates above.
+4. Summarize results + provide a PR-ready `CHANGELOG.md` entry (with a `### Renamed` section if any term moved, as `old -> new`).
 
 ## Safety rails
 - Do NOT delete terms that may be referenced externally. Deprecate and map replacements.
 - Do NOT "rename by IRI change". Labels can change; IRIs should not.
+- Everything in `dist/` is generated — regenerate, never hand-edit.
 - If a request conflicts with best practice, push back and offer 2–3 safer alternatives.
-
-## Communication format
-- Use this structure in your responses:
-  1) What I understood
-  2) Plan
-  3) Proposed modeling (with rationale)
-  4) Implementation notes
-  5) Validation results
-  6) Changelog snippet

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,11 +1,43 @@
 cff-version: 1.2.0
-message: "If you use this software, please cite it as below."
-authors:
-- family-names: "Huzard"
-  given-names: "Damien"
-  orcid: "https://orcid.org/0000-0003-4820-7951"
+message: "If you use this software/ontology, please cite it as below."
 title: "The Home-Cage Monitoring Ontology (HCMO)"
+abstract: >-
+  An ontology for home-cage monitoring of laboratory animals, modeling
+  monitored enclosures, subjects, environment and observation data, sensors and
+  hardware/software, in the MAPP (Monitoring and Analytics for Physiological
+  Processes) framework.
+type: dataset
+authors:
+  - family-names: "Huzard"
+    given-names: "Damien"
+    orcid: "https://orcid.org/0000-0003-4820-7951"
+  - family-names: "Todorov"
+    given-names: "Konstantin"
+    orcid: "https://orcid.org/0000-0002-9116-6692"
+  - family-names: "Gilbert"
+    given-names: "Cyril"
+    # orcid: "https://orcid.org/0000-0000-0000-0000"  # TODO: add ORCID
+  - family-names: "Larmande"
+    given-names: "Pierre"
+    orcid: "https://orcid.org/0000-0002-2923-9790"
+  - family-names: "Sanou"
+    given-names: "Gaoussou"
+    # orcid: "https://orcid.org/0000-0000-0000-0000"  # TODO: add ORCID
+  - family-names: "Sonfack"
+    given-names: "Serge"
+    # orcid: "https://orcid.org/0000-0000-0000-0000"  # TODO: add ORCID
+  - family-names: "Tofano"
+    given-names: "Antoine"
+    # orcid: "https://orcid.org/0000-0000-0000-0000"  # TODO: add ORCID
 version: 0.1
 doi: 10.5281/zenodo.18925285
 date-released: 2026-03-09
 url: "https://github.com/dhuzard/HCMO"
+repository-code: "https://github.com/Neuronautix/HCMO"
+license: CC-BY-4.0
+keywords:
+  - ontology
+  - home-cage monitoring
+  - laboratory animals
+  - semantic web
+  - FAIR data

--- a/README.md
+++ b/README.md
@@ -1,233 +1,130 @@
-# HCMO Ontology (Home-Cage Monitoring Ontology)
+# HCMO — Home-Cage Monitoring Ontology
 
-> **MAPP 0.0.1 — repository reorganized as a standalone, tool-consumable ontology project.**
-> The active ontology is the **MAPP** ontology (Monitoring and Analytics for
-> Physiological Processes), ontology IRI `https://w3id.org/hcmo/ontology/hcm`,
-> namespace `https://w3id.org/hcmo/ontology/hcm#` (module sub-namespaces
-> `…/hcm/bio#`, `…/hcm/env#`, `…/hcm/obs#`). It carries forward this established
-> namespace; the prior HCMO 1.0.0 term set is preserved under `ontology/legacy/`.
-> See `CHANGELOG.md`.
->
-> **Release contract:** [`hcmo.yaml`](hcmo.yaml) — the stable manifest downstream
-> tools (e.g. the hcmo-kgqa-lab sync layer) read.
->
-> **Layout:**
-> - `hcmo.yaml` — release manifest (name, version, namespace, modules, dist, shapes, queries, examples).
-> - `ontology/modules/*.ttl` — hand-authored modular sources (`hcm-core`, `hcm-bio`, `hcm-env`, `hcm-obs`).
-> - `ontology/context.jsonld` — JSON-LD context.
-> - `dist/` — **generated** (`hcmo.ttl` merged/canonical, `hcmo.owl`, `hcmo.json`, `profile.json`). Never hand-edit.
-> - `shapes/`, `examples/`, `queries/` — SHACL, ABox examples, competency queries (see `docs/MISSING-DEFINITIONS.md` re: namespace).
-> - `tooling/build.py` — regenerate `dist/` + `profile.json` (idempotent, reproducible).
-> - `tooling/validate.py` — parse + pySHACL + competency-query gate (used by CI).
-> - `ontology/legacy/` — the previous HCMO 1.0.0 ontology, retained, not deleted.
->
-> **Build & validate:**
-> ```bash
-> pip install -r tooling/requirements.txt
-> python tooling/build.py      # regenerate dist/ + profile.json
-> python tooling/validate.py   # parse + SHACL + competency queries (CI gate)
-> ```
+[![Validate](https://github.com/Neuronautix/HCMO/actions/workflows/validate.yml/badge.svg)](https://github.com/Neuronautix/HCMO/actions/workflows/validate.yml)
+[![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-blue.svg)](LICENSE)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.18925285-blue.svg)](https://doi.org/10.5281/zenodo.18925285)
 
-A professional, reusable ontology package for home-cage monitoring (HCMO). It models systems, animals, enclosures, behaviors, sensors/actuators, observation windows, and provisioning needs; aligns to key web standards; ships with SHACL validation, examples, queries, and a JSON-LD context for application developers.
+HCMO is an ontology for **home-cage monitoring** of laboratory animals. It models
+monitored enclosures, biological subjects and experimental groups, the
+environment and its measurements, observations and results, and the sensors,
+hardware, and software that produce the data — under the **MAPP** framework
+(Monitoring and Analytics for Physiological Processes). The project ships as a
+standalone, tool-consumable package: a stable release manifest, modular Turtle
+sources, generated distributions, SHACL shapes, competency queries, and a
+JSON-LD context.
 
-- Ontology core: `ontology/hcm.ttl`
-- Standards alignment: `ontology/hcm-align.ttl`
-- Ontology metadata and imports: `ontology/hcm-metadata.ttl`
-- Optional bridge modules: `ontology/hcm-bridge-*.ttl`
-- SHACL shapes: `shapes/hcm-shapes.ttl`
-- Examples (ABox): `examples/`
-- SPARQL queries: `queries/`
-- JSON-LD context: `ontology/context.jsonld`
-- Validation scripts and CI: `tooling/validate.ps1`, `tooling/validate.sh`, `.github/workflows/validate.yml`
-- Web-based authoring app: `webapp/`
+## At a glance
 
-## Why HCMO?
-- **Interoperability**: Aligns with SOSA/SSN (sensing/actuation), OWL-Time, PROV, and BFO.
-- **Data quality**: Enforces practical constraints (> 24 h observation window, enclosure space/dimensions, system composition) with SHACL.
-- **Developer-ready**: JSON-LD context and examples; simple upgrade path to QUDT/OM units.
-- **FAIR**: Clear IRIs, metadata, governance, and publishing guidance.
+| | |
+|---|---|
+| **Ontology IRI** | `https://w3id.org/hcmo/ontology/hcm` |
+| **Base namespace** | `https://w3id.org/hcmo/ontology/hcm#` |
+| **Module sub-namespaces** | `…/hcm/bio#`, `…/hcm/env#`, `…/hcm/obs#` |
+| **Version** | `0.0.1` (versionIRI `…/hcm/0.0.1`) |
+| **Prefix** | `hcm` |
+| **License** | CC BY 4.0 |
+| **Release manifest** | [`hcmo.yaml`](hcmo.yaml) |
 
-## Repository Map
-- `ontology/` - Core ontology Turtle files, metadata, and JSON-LD context.
-- `shapes/` - SHACL shapes used to validate HCMO payloads.
-- `examples/` - Sample ABox datasets demonstrating minimal and edge-case coverage.
-- `queries/` - SPARQL queries for common analysis scenarios.
-- `tooling/` - Validation scripts, ROBOT report config, and Python requirements for ontology QA.
-- `webapp/` - Node.js authoring and blueprint checklist application.
-- `docs/` - Supporting documentation, including field tiers and alignment notes.
-- `docs/ARCHITECTURE.md` - Modular architecture plan and bridge module rules.
-- `.github/` - CI workflow and issue templates.
+> The release manifest [`hcmo.yaml`](hcmo.yaml) is the **contract** that
+> downstream tools (e.g. the `hcmo-kgqa-lab` sync layer) read. Its shape is
+> treated as an API and kept stable across releases.
 
-## Prerequisites and Installation
-### Ontology tooling
-- Install Python 3.11 or later.
-- From the repository root, install validation dependencies once: `pip install -r tooling/requirements.txt`.
+## Repository layout
 
-### Web authoring app
-- Install Node.js 20.x or later.
-- Change into `webapp/` and install dependencies: `npm install`.
-
-## Ontology validation workflow
-Run the full validation loop from the repository root:
-
-```powershell
-./tooling/validate.ps1
 ```
-
-Linux/macOS (bash):
-```bash
-./tooling/validate.sh
+hcmo.yaml                      # release manifest (name, version, namespace, modules, dist, shapes, queries, examples)
+ontology/
+  modules/                     # hand-authored modular sources
+    hcm-core.ttl               #   core terms + owl:Ontology header (attribution)
+    hcm-bio.ttl                #   subjects, experimental groups        (…/hcm/bio#)
+    hcm-env.ttl                #   environment & measurements           (…/hcm/env#)
+    hcm-obs.ttl                #   observations & results               (…/hcm/obs#)
+  context.jsonld               # JSON-LD context for app developers
+  legacy/                      # previous HCMO 1.0.0 ontology (retained, not merged)
+dist/                          # GENERATED — never hand-edit
+  hcmo.ttl                     #   merged graph, canonical/sorted Turtle (reproducible)
+  hcmo.owl                     #   merged graph, RDF/XML
+  hcmo.json                    #   merged graph, JSON-LD
+  profile.json                 #   flat term inventory {iri,label,comment} + counts
+shapes/hcm-shapes.ttl          # SHACL constraints
+examples/                      # ABox examples (abox-minimal, abox-edge-cases)
+queries/                       # competency_questions.yaml + cq-*.rq
+tooling/                       # build.py, validate.py, requirements.txt
+docs/                          # documentation (incl. MISSING-DEFINITIONS.md)
+.github/workflows/             # validate.yml (PR gate), release.yml (tag → assets)
+webapp/                        # optional Node.js authoring/blueprint app
 ```
-
-The script will:
-1. Ensure `pyshacl` and `rdflib` are available (and install them if missing).
-2. Parse every Turtle file under `ontology/`, `shapes/`, and `examples/`, emitting `[OK] Parsed: <file>` lines.
-3. Validate `examples/abox-minimal.ttl` against `shapes/hcm-shapes.ttl` with `pyshacl -f human`.
-
-A successful run ends with `Validation passed.`. If parsing or validation fails, the script stops with `Validation failed.` and the upstream error. Troubleshooting tips:
-- Confirm Python 3.11+ is on PATH and `pip install -r tooling/requirements.txt` succeeds.
-- Use the `-Data` and `-Shapes` parameters to point at alternate Turtle files when developing new payloads.
-- If SHACL errors persist, open the report written to the console and cross-reference the offending shapes in `shapes/hcm-shapes.ttl`.
-
-## Web authoring app
-### Launch the app
-```powershell
-cd webapp
-npm run dev
-```
-The server starts on `http://localhost:3000`.
-
-### System Export tab
-- Capture system, enclosure, sensors, actuators, welfare needs, and time interval details.
-- Submit the form to receive JSON-LD, Turtle, and pySHACL validation output. Three panels appear with copyable text areas plus `Download` buttons.
-- The `Download ZIP Bundle` button bundles the JSON-LD, Turtle, and validation report for sharing with downstream systems.
-
-### Blueprint tab
-- `docs/FIELD-TIERS.md` supplies the tier inventory surfaced in the UI. Fields are grouped as mandatory, recommended, or optional with rationale and example values.
-- The app queries `/api/blueprint/inventory` and `/api/blueprint/examples` to populate tiers and sample datasets. Select an example dataset and click **Load Example** to prefill statuses and notes.
-- Update field values and statuses (`provided`, `partial`, `missing`, `unknown`) to track coverage. Summary tiles recompute weighted coverage and mandatory completion as you edit.
-- Use **Clear Fields** to reset the checklist before exporting or sharing results.
-
-## Consuming the ontology
-- Import `ontology/hcm.ttl`, `ontology/hcm-align.ttl`, and `ontology/hcm-metadata.ttl` into your triple store or reasoning environment.
-- Optional: import `ontology/hcm-bridge-*.ttl` for domain-specific alignments (e.g., animal or device ontologies).
-- Apply the JSON-LD context (`ontology/context.jsonld`) when exchanging data with web applications.
-- Use `shapes/hcm-shapes.ttl` to enforce constraints during ingestion pipelines or data QA. The shapes expect the same structure the webapp produces.
-- Explore the SPARQL queries in `queries/` (for example `cq-systems-24h-limited.rq`) to answer common competency questions about systems, intervals, and welfare coverage.
-
-## Example data
-- `examples/abox-minimal.ttl` - A conformant payload matching the mandatory field coverage described in the blueprint.
-- `examples/abox-edge-cases.ttl` - Intentionally invalid scenarios (missing sensors, short intervals, etc.) to exercise SHACL failure paths.
-Adapt either file by copying it into a working directory and editing IDs, labels, and measurements while keeping the ontology structure intact.
-
-## Tooling scripts
-Currently available:
-- `tooling/validate.ps1` - orchestrates Turtle parsing and pySHACL validation (see above).
-- `tooling/validate.sh` - bash equivalent for validation on Linux/macOS.
-- `tooling/requirements.txt` - pinned dependencies for validation tooling.
-- `tooling/robot-report.tsv` - ROBOT report profile for labels/definitions/provenance.
-- `tooling/robot-report.md` - ROBOT report usage and output format.
-
-The blueprint TODO (below) tracks planned additions such as a checklist scoring helper and metadata entry CLI; those scripts are not yet implemented.
-
-## Testing
-Inside `webapp/`, run the front-end API and UI tests:
-```powershell
-npm test
-```
-This exercises the blueprint inventory endpoints and UI guardrails. Run the suite before submitting changes to the form logic, API handlers, or blueprint resources.
-
-## Contribution and support
-- Open issues or feature requests through GitHub Issues; use the templates in `.github/ISSUE_TEMPLATE/` when applicable.
-- Follow the existing coding style (ES modules in the webapp, Turtle/JSON-LD formatting in ontology assets) and document non-obvious changes inline or in `docs/`.
-- Reference semantic version information from `ontology/hcm-metadata.ttl` (current version IRI `https://w3id.org/hcmo/ontology/hcm/1.0.0`) when publishing derived packages.
-- For security or data governance concerns, contact the maintainers via the repository issue tracker before disclosing sensitive details.
 
 ## Quickstart
-1. Install validation tooling and webapp dependencies (see prerequisites above).
-2. Run `./tooling/validate.ps1` to confirm ontology and example integrity.
-3. Launch the webapp with `npm run dev` and generate a sample export.
-4. Import `ontology/hcm.ttl` plus `examples/abox-minimal.ttl` into your triple store and test the queries in `queries/`.
 
-## Ontology blueprint TODO
+```bash
+pip install -r tooling/requirements.txt
 
-- Audit existing repo assets (`README`, `docs/`, `schemas/`, `scripts/`) for existing TEATIME/HCM coverage and identify reuse or gaps.
-- Add an updated YAML representation of the ontology blueprint under `ontology/` for downstream tooling.
-- Collect the latest TEATIME HCM ontology schema and Bains et al. *"Too Big to Lose"* metadata definitions in `reference/ontology/`.
-- Gather the representative device's metadata/export specifications (field names, types, units, sampling cadence) in `reference/device/`.
-- Design a canonical ontology-field inventory spanning subjects, environment, hardware, software, and outputs as a repo-consumable artifact.
-- Map device fields to ontology terms, capturing matches, transforms, gaps, and source notes for stakeholder review.
-- Implement a checklist scaffold (spreadsheet in `docs/` plus machine-readable export) tracking check / warning / fail coverage and rationale.
-- Prototype an automated scoring routine summarizing coverage by domain and overall alignment using sample metadata.
-- Draft a stakeholder memo summarizing ambiguous mappings, open questions, and proposed device-specific extensions.
-- Record outcomes of the stakeholder feedback loop and propagate approved adjustments into the mapping artifacts.
-- Finalize blueprint deliverables (checklist, README/SOP, reproducible mapping workflow) and plan OSF or similar deposition.
-- Capture beta metadata-entry tool requirements (inputs, validation, JSON-LD/CSV export) and log follow-up implementation issues.
-
-### Completed
-
-- Classify each ontology field as Mandatory, Recommended, or Optional with supporting evidence (`docs/FIELD-TIERS.md`).
-
-**Blueprint assets**  
-- YAML blueprint: `ontology/hcm-blueprint.yaml`  
-- Field inventory: `ontology/hcm-field-inventory.tsv`  
-- Device export spec: `reference/device/representative-device-export.yaml`  
-- Device mapping log: `reference/device/device-to-ontology-mapping.csv`  
-- Coverage checklist: `docs/hcm-blueprint-checklist.csv` and `docs/hcm-blueprint-checklist.json`  
-- Scoring script: `node tooling/score_blueprint.mjs [checklist]`  
-- Metadata-entry tool: `node tooling/metadata_entry_tool.mjs --format jsonld|csv --out <file>`  
-- SOP and issue log: `docs/BLUEPRINT-SOP.md`, `docs/metadata-entry-tool-issues.md`
-
-## Namespaces and IRIs
-- Base ontology IRI: `https://w3id.org/hcmo/ontology/hcm`
-- Version IRI: `https://w3id.org/hcmo/ontology/hcm/1.0.0`
-- Prefixes used: `hcm`, `sosa`, `ssn`, `time`, `prov`, `dcterms`, `qudt`, `unit`, `om`, `schema`, `bfo`
-
-See alignments in `docs/ALIGNMENTS.md`.
-
-## What's in the ontology
-
-**Core classes (selected)**  
-- `hcm:System` - HCM system composed of enclosure, hardware, and software.  
-- `hcm:Animal` - Experimental animal.  
-- `hcm:Enclosure` - Artifact enclosure linked to `hcm:PhysicalSpace`.  
-- `hcm:BehaviorAndPhysiology` - Observed process captured over an `hcm:ObservationWindow`.  
-- `hcm:Sensor`, `hcm:Actuator`, `hcm:Hardware`, `hcm:Software`, `hcm:Supplier` (+ subtypes).  
-- `hcm:AnimalNeedProfile`, `hcm:LimitedInteractionWithHumans`, `hcm:Dimensions`, `hcm:ObservationWindow`.  
-
-**Key object properties**  
-- System composition: `hcm:hasEnclosure`, `hcm:hasHardware`, `hcm:hasSoftware`, `hcm:producedBy`.  
-- Hardware IO: `hcm:hasSensorComponent`, `hcm:hasActuatorComponent`; system-level `hcm:hasSensor`/`hcm:hasActuator` via property chains.  
-- Animal, enclosure, needs: `hcm:livesIn`, `hcm:providesNeedProfile`, `hcm:requiresToThrive`.  
-- Behavior context: `hcm:isDisplayedInside`, `hcm:hasCircadianRhythm`, `hcm:isCapturedOver`.  
-- Space and geometry: `hcm:hasSpaceRegion`, `hcm:hasDimensions`.  
-
-**Key datatype properties**  
-- Dimensions: `hcm:width`, `hcm:length`, `hcm:height`, `hcm:unit`.  
-- Observation window: `hcm:durationHours`, `hcm:isExtendable`.  
-
-**Selected OWL axioms**  
-- Disjointness: `hcm:Sensor` disjoint `hcm:Actuator`, `hcm:Hardware` disjoint `hcm:Software`.  
-- Restrictions: `hcm:System` has at least one enclosure, hardware, and software; property chains derive system sensors/actuators from hardware components.  
-
-## Standards alignment
-
-- SOSA/SSN: `hcm:Sensor` subset of `sosa:Sensor`, `hcm:Actuator` subset of `sosa:Actuator`, `hcm:System` subset of `sosa:Platform`, `hcm:hasSensor` subset of `sosa:hosts`.  
-- OWL-Time: `hcm:ObservationWindow` subset of `time:TemporalEntity`.  
-- PROV/Agents: `hcm:producedBy` subset of `prov:wasAttributedTo`; `hcm:Supplier` subset of `prov:Agent` and `schema:Organization`.  
-- BFO: `hcm:BehaviorAndPhysiology` subset of `bfo:0000015` (process).  
-
-Details and rationale are documented in `docs/ALIGNMENTS.md`.
-
-## SHACL validation
-
-Shapes in `shapes/hcm-shapes.ttl` check:  
-- System: at least one enclosure, hardware, and software.  
-- Observation window: `durationHours` > 24, optional `isExtendable`.  
-- Enclosure: must have a `PhysicalSpace` via `hasSpaceRegion`.  
-- Dimensions: width, length, height > 0; unit present.  
-
-Run locally (PowerShell):  
-```powershell
-./tooling/validate.ps1
+python tooling/build.py      # regenerate dist/ + profile.json (idempotent, reproducible)
+python tooling/validate.py   # parse all TTL + pySHACL + competency queries (the CI gate)
 ```
+
+- **`tooling/build.py`** merges `ontology/modules/*.ttl` into `dist/` using a
+  canonicalized, sorted serialization, so re-running produces byte-identical
+  output (clean diffs). Everything in `dist/` is generated — edit the modules,
+  not the artifacts.
+- **`tooling/validate.py`** parses every TTL, runs the SHACL shapes against the
+  examples, and runs every `queries/cq-*.rq` against the merged graph; it exits
+  non-zero on failure. It is the same check the PR workflow runs.
+
+## Consuming the ontology
+
+- **Merged graph:** import `dist/hcmo.ttl` (or `dist/hcmo.owl`) into your triple
+  store or reasoner.
+- **Programmatic inventory:** read `dist/profile.json` for the flat list of
+  classes / object properties / datatype properties with labels, comments, and
+  counts — ideal for sync layers and UIs.
+- **JSON-LD apps:** apply `ontology/context.jsonld` when exchanging data.
+- **Validation:** use `shapes/hcm-shapes.ttl` to validate payloads during
+  ingestion; see `examples/` for conformant and intentionally-invalid ABoxes.
+- **Everything is discoverable from `hcmo.yaml`** — resolve module, dist, shapes,
+  queries, and example paths from there rather than hard-coding them.
+
+## Status & known issues
+
+This is an early release (`0.0.1`) derived from a Chowlk diagram export.
+`docs/MISSING-DEFINITIONS.md` tracks the open data-quality work, including:
+
+- Terms still lacking `rdfs:comment` definitions (labels are present).
+- Chowlk placeholder/erroneous terms preserved as authored (`UNKNOWN:*`,
+  `ns:Class2`, `xsd:boolean`/`xsd:integer` typed as properties) — to be re-mapped
+  or removed at the source.
+- `shapes/`, `examples/`, and `queries/` currently reference the legacy 1.0.0
+  term set and need re-authoring against the MAPP terms (competency queries
+  return 0 rows until then).
+
+Per project policy, missing labels and definitions are **listed, not fabricated**.
+
+## Web authoring app (optional)
+
+A Node.js app under `webapp/` supports form-based authoring and a blueprint
+checklist. From `webapp/`: `npm install` then `npm run dev` (serves on
+`http://localhost:3000`); `npm test` runs the API/UI tests. The app predates the
+MAPP reorganization and targets the legacy term set.
+
+## Contributors
+
+- **Damien Huzard** — [0000-0003-4820-7951](https://orcid.org/0000-0003-4820-7951)
+- **Konstantin Todorov** — [0000-0002-9116-6692](https://orcid.org/0000-0002-9116-6692)
+- **Cyril Gilbert** — _ORCID: TBD_
+- **Pierre Larmande** — [0000-0002-2923-9790](https://orcid.org/0000-0002-2923-9790)
+- **Gaoussou Sanou** — _ORCID: TBD_
+- **Serge Sonfack** — _ORCID: TBD_
+- **Antoine Tofano** — _ORCID: TBD_
+
+Attribution is also recorded on the `owl:Ontology` header (`dcterms:creator`,
+using ORCID IRIs where known) and in [`CITATION.cff`](CITATION.cff).
+
+## Citation
+
+If you use HCMO, please cite it via [`CITATION.cff`](CITATION.cff) (GitHub's
+"Cite this repository") or the DOI [10.5281/zenodo.18925285](https://doi.org/10.5281/zenodo.18925285).
+
+## License
+
+Released under [CC BY 4.0](LICENSE).

--- a/dist/hcmo.json
+++ b/dist/hcmo.json
@@ -240,6 +240,11 @@
       "rdfs:label": "supports enclosure"
     },
     {
+      "@id": "_:cb160c7c4054321f6a510d5f5989b3a5691f1f291b6a0f61e5277528d2f6939dfa8",
+      "@type": "schema:Person",
+      "schema:name": "Cyril Gilbert"
+    },
+    {
       "@id": "_:cb16ecbbc8bf4babbcae00a50aaf1e70557b2dd74f57693930fbe651ab1ed75e499",
       "@type": "owl:Restriction",
       "owl:allValuesFrom": {
@@ -248,6 +253,11 @@
       "owl:onProperty": {
         "@id": "hcm-env:hasMeasurementSpec"
       }
+    },
+    {
+      "@id": "_:cb16ed6fc717ad5d6768187410fe718b5cc7a2ce7d1fb6059fbb4c1d434bfe6ce1c",
+      "@type": "schema:Person",
+      "schema:name": "Gaoussou Sanou"
     },
     {
       "@id": "_:cb1927685761ff8827d6b6aa29d9020102456bb3441f2299305340b361363817349",
@@ -261,6 +271,11 @@
       }
     },
     {
+      "@id": "_:cb192a98778b14bb7268e9f35693b103bf9fa8bd8b8f67b01a2ede6deb98433886f",
+      "@type": "schema:Person",
+      "schema:name": "Antoine Tofano"
+    },
+    {
       "@id": "_:cb1973efc7f24e152ca98a85ff21b8c66dd7e164ae7d89060a391a90f98e4f00834",
       "@type": "owl:Restriction",
       "owl:allValuesFrom": {
@@ -269,6 +284,11 @@
       "owl:onProperty": {
         "@id": "hcm-bio:belongsToGroup"
       }
+    },
+    {
+      "@id": "_:cb19eb4d2089a2fe8c838a2de87ce1941cfc86dbada43b73334ecc2002d4b96a699",
+      "@type": "schema:Person",
+      "schema:name": "Serge Sonfack"
     },
     {
       "@id": "_:cb1a90ed890653fe72b8d32c4bb3dbcb89d9ee3d9ab3d4df5d9718ba4f815cd0026",
@@ -1658,11 +1678,48 @@
       "rdfs:label": "monitored by"
     },
     {
+      "@id": "https://orcid.org/0000-0002-2923-9790",
+      "@type": "schema:Person",
+      "schema:name": "Pierre Larmande"
+    },
+    {
+      "@id": "https://orcid.org/0000-0002-9116-6692",
+      "@type": "schema:Person",
+      "schema:name": "Konstantin Todorov"
+    },
+    {
+      "@id": "https://orcid.org/0000-0003-4820-7951",
+      "@type": "schema:Person",
+      "schema:name": "Damien Huzard"
+    },
+    {
       "@id": "https://w3id.org/hcmo/ontology/hcm",
       "@type": "owl:Ontology",
-      "dc:creator": "Damien/Cyril",
       "dc:description": "Ontology for Monitoring and Analytics for Physiological Processes (MAPP)",
       "dc:title": "MAPP Ontology",
+      "dcterms:creator": [
+        {
+          "@id": "_:cb160c7c4054321f6a510d5f5989b3a5691f1f291b6a0f61e5277528d2f6939dfa8"
+        },
+        {
+          "@id": "_:cb16ed6fc717ad5d6768187410fe718b5cc7a2ce7d1fb6059fbb4c1d434bfe6ce1c"
+        },
+        {
+          "@id": "_:cb192a98778b14bb7268e9f35693b103bf9fa8bd8b8f67b01a2ede6deb98433886f"
+        },
+        {
+          "@id": "_:cb19eb4d2089a2fe8c838a2de87ce1941cfc86dbada43b73334ecc2002d4b96a699"
+        },
+        {
+          "@id": "https://orcid.org/0000-0002-2923-9790"
+        },
+        {
+          "@id": "https://orcid.org/0000-0002-9116-6692"
+        },
+        {
+          "@id": "https://orcid.org/0000-0003-4820-7951"
+        }
+      ],
       "mod:createdWith": {
         "@id": "https://chowlk.linkeddata.es/"
       },

--- a/dist/hcmo.owl
+++ b/dist/hcmo.owl
@@ -4,8 +4,10 @@
   xmlns:owl="http://www.w3.org/2002/07/owl#"
   xmlns:mod="https://w3id.org/mod#"
   xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:schema="https://schema.org/"
   xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:dcterms="http://purl.org/dc/terms/"
 >
   <owl:Class rdf:about="https://w3id.org/hcmo/ontology/hcm#MonitoredEnclosure">
     <rdfs:label>Monitored Enclosure</rdfs:label>
@@ -309,6 +311,48 @@
   <owl:DatatypeProperty rdf:about="http://www.owl-ontologies.com/UNKNOWN#hasSensorTechnology">
     <rdfs:label>has sensor technology</rdfs:label>
   </owl:DatatypeProperty>
+  <owl:Ontology rdf:about="https://w3id.org/hcmo/ontology/hcm">
+    <dc:description>Ontology for Monitoring and Analytics for Physiological Processes (MAPP)</dc:description>
+    <dc:title>MAPP Ontology</dc:title>
+    <dcterms:creator>
+      <schema:Person rdf:nodeID="cb160c7c4054321f6a510d5f5989b3a5691f1f291b6a0f61e5277528d2f6939dfa8">
+        <schema:name>Cyril Gilbert</schema:name>
+      </schema:Person>
+    </dcterms:creator>
+    <dcterms:creator>
+      <schema:Person rdf:nodeID="cb16ed6fc717ad5d6768187410fe718b5cc7a2ce7d1fb6059fbb4c1d434bfe6ce1c">
+        <schema:name>Gaoussou Sanou</schema:name>
+      </schema:Person>
+    </dcterms:creator>
+    <dcterms:creator>
+      <schema:Person rdf:nodeID="cb192a98778b14bb7268e9f35693b103bf9fa8bd8b8f67b01a2ede6deb98433886f">
+        <schema:name>Antoine Tofano</schema:name>
+      </schema:Person>
+    </dcterms:creator>
+    <dcterms:creator>
+      <schema:Person rdf:nodeID="cb19eb4d2089a2fe8c838a2de87ce1941cfc86dbada43b73334ecc2002d4b96a699">
+        <schema:name>Serge Sonfack</schema:name>
+      </schema:Person>
+    </dcterms:creator>
+    <dcterms:creator>
+      <schema:Person rdf:about="https://orcid.org/0000-0002-2923-9790">
+        <schema:name>Pierre Larmande</schema:name>
+      </schema:Person>
+    </dcterms:creator>
+    <dcterms:creator>
+      <schema:Person rdf:about="https://orcid.org/0000-0002-9116-6692">
+        <schema:name>Konstantin Todorov</schema:name>
+      </schema:Person>
+    </dcterms:creator>
+    <dcterms:creator>
+      <schema:Person rdf:about="https://orcid.org/0000-0003-4820-7951">
+        <schema:name>Damien Huzard</schema:name>
+      </schema:Person>
+    </dcterms:creator>
+    <owl:versionIRI rdf:resource="https://w3id.org/hcmo/ontology/hcm/0.0.1"/>
+    <owl:versionInfo>0.0.1</owl:versionInfo>
+    <mod:createdWith rdf:resource="https://chowlk.linkeddata.es/"/>
+  </owl:Ontology>
   <owl:DatatypeProperty rdf:about="https://w3id.org/hcmo/ontology/hcm#hasDescription">
     <rdfs:label>has description</rdfs:label>
   </owl:DatatypeProperty>
@@ -402,14 +446,6 @@
     <rdfs:label>Study Factors</rdfs:label>
     <rdfs:subClassOf rdf:resource="https://w3id.org/hcmo/ontology/hcm#MonitoredEnclosure"/>
   </owl:Class>
-  <owl:Ontology rdf:about="https://w3id.org/hcmo/ontology/hcm">
-    <dc:creator>Damien/Cyril</dc:creator>
-    <dc:description>Ontology for Monitoring and Analytics for Physiological Processes (MAPP)</dc:description>
-    <dc:title>MAPP Ontology</dc:title>
-    <owl:versionIRI rdf:resource="https://w3id.org/hcmo/ontology/hcm/0.0.1"/>
-    <owl:versionInfo>0.0.1</owl:versionInfo>
-    <mod:createdWith rdf:resource="https://chowlk.linkeddata.es/"/>
-  </owl:Ontology>
   <owl:DatatypeProperty rdf:about="http://www.owl-ontologies.com/UNKNOWN#hasFoodReq">
     <rdfs:label>has food req</rdfs:label>
   </owl:DatatypeProperty>

--- a/dist/hcmo.ttl
+++ b/dist/hcmo.ttl
@@ -3,6 +3,7 @@
 # Edit the modules and re-run `python tooling/build.py` to regenerate.
 @prefix UNKNOWN: <http://www.owl-ontologies.com/UNKNOWN#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix hcm: <https://w3id.org/hcmo/ontology/hcm#> .
 @prefix hcm-bio: <https://w3id.org/hcmo/ontology/hcm/bio#> .
 @prefix hcm-env: <https://w3id.org/hcmo/ontology/hcm/env#> .
@@ -11,6 +12,7 @@
 @prefix ns: <http://www.owl-ontologies.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
 @prefix semts: <https://w3id.org/semts/ontology/120#> .
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix time: <http://www.w3.org/2006/time#> .
@@ -138,9 +140,19 @@ xsd:integer a owl:DatatypeProperty ;
 owl:versionInfo a owl:AnnotationProperty .
 
 <https://w3id.org/hcmo/ontology/hcm> a owl:Ontology ;
-    dc:creator "Damien/Cyril" ;
     dc:description "Ontology for Monitoring and Analytics for Physiological Processes (MAPP)" ;
     dc:title "MAPP Ontology" ;
+    dcterms:creator [ a schema:Person ;
+            schema:name "Cyril Gilbert" ],
+        [ a schema:Person ;
+            schema:name "Gaoussou Sanou" ],
+        [ a schema:Person ;
+            schema:name "Antoine Tofano" ],
+        [ a schema:Person ;
+            schema:name "Serge Sonfack" ],
+        <https://orcid.org/0000-0002-2923-9790>,
+        <https://orcid.org/0000-0002-9116-6692>,
+        <https://orcid.org/0000-0003-4820-7951> ;
     owl:versionIRI <https://w3id.org/hcmo/ontology/hcm/0.0.1> ;
     owl:versionInfo "0.0.1" ;
     mod:createdWith <https://chowlk.linkeddata.es/> .
@@ -305,6 +317,15 @@ sosa:madeBySensor a owl:ObjectProperty ;
 
 sosa:madeObservation a owl:ObjectProperty ;
     rdfs:label "made observation" .
+
+<https://orcid.org/0000-0002-2923-9790> a schema:Person ;
+    schema:name "Pierre Larmande" .
+
+<https://orcid.org/0000-0002-9116-6692> a schema:Person ;
+    schema:name "Konstantin Todorov" .
+
+<https://orcid.org/0000-0003-4820-7951> a schema:Person ;
+    schema:name "Damien Huzard" .
 
 hcm:QuantityValue a owl:Class ;
     rdfs:label "Quantity Value" .

--- a/dist/profile.json
+++ b/dist/profile.json
@@ -189,7 +189,7 @@
     "classes": 32,
     "datatype_properties": 73,
     "object_properties": 38,
-    "triples": 594
+    "triples": 614
   },
   "datatype_properties": [
     {

--- a/ontology/AGENTS.md
+++ b/ontology/AGENTS.md
@@ -1,43 +1,40 @@
 # AGENTS.md — Ontology Workspace (ontology/)
 
-This folder contains the ontology source of truth. Generated files should not be edited by hand.
+This folder contains the ontology source of truth. Generated files (`../dist/`) must not be edited by hand.
 
 ## Architecture (repo-specific)
-- `hcm.ttl` : core ontology terms and axioms (authoritative source)
-- `hcm-align.ttl` : external standards alignments
-- `hcm-metadata.ttl` : ontology metadata and import declarations
-- `hcm-bridge-*.ttl` : optional bridge modules for external domain ontologies
-- `context.jsonld` : JSON-LD context for application developers
+- `modules/hcm-core.ttl` : core terms, axioms, and the `owl:Ontology` header (incl. `dcterms:creator` attribution).
+- `modules/hcm-bio.ttl`  : biological subjects/groups (namespace `…/hcm/bio#`).
+- `modules/hcm-env.ttl`  : environment & measurement terms (namespace `…/hcm/env#`).
+- `modules/hcm-obs.ttl`  : observations & results (namespace `…/hcm/obs#`).
+- `context.jsonld`       : JSON-LD context for application developers.
+- `legacy/`              : the previous HCMO 1.0.0 ontology (retained, not merged).
 
-## Canonical modeling patterns (project-specific)
-Authoritative notes live in `docs/MODEL.md`. Use ONLY these patterns unless you propose a change:
-1) Behavior as process:
-   - `hcm:BehaviorAndPhysiology` is a process (BFO-aligned)
-2) Observation window:
-   - `hcm:TimeInterval` with `hcm:durationHours` >= 24 and limited human interaction
-3) System composition:
-   - `hcm:System` uses `hcm:hasEnclosure`, `hcm:hasHardware`, `hcm:hasSoftware`,
-     `hcm:hasSensor`, `hcm:hasActuator`
-4) Needs:
-   - simple boolean decomposition (upgrade to classes only if justified)
-5) Dimensions:
-   - simple datatype pattern; roadmap to QUDT/OM if needed
+The merged graph is the union of `modules/*.ttl`, produced by `../tooling/build.py` into `../dist/`.
+Module load order and all paths are declared in `../hcmo.yaml`.
+
+## Namespaces
+- Base: `https://w3id.org/hcmo/ontology/hcm#` (ontology IRI `https://w3id.org/hcmo/ontology/hcm`).
+- Sub-namespaces are path segments: `…/hcm/bio#`, `…/hcm/env#`, `…/hcm/obs#`.
+- Put each new term in the module matching its namespace.
 
 ## Required annotations (per entity)
-- label: rdfs:label
-- definition: IAO:0000115 (or the project's definition property)
-- editor note / provenance: project choice (keep lightweight)
-- created/modified dates only if the repo already enforces them (avoid inventing metadata rules)
+- label: `rdfs:label`
+- definition: `rdfs:comment` and/or `IAO:0000115`
+- provenance / editor note: lightweight, project choice
+- Do not invent labels/definitions. Missing ones are listed in `../docs/MISSING-DEFINITIONS.md`.
+
+## Known data-quality debt (see ../docs/MISSING-DEFINITIONS.md)
+- Many terms still lack `rdfs:comment` definitions.
+- Chowlk export artifacts are preserved as authored (e.g. `UNKNOWN:*`, `ns:Class2`,
+  `xsd:boolean`/`xsd:integer` typed as properties) — review and re-map/remove at the source, do not silently delete.
 
 ## Deprecation & replacements
-When deprecating:
-- keep the IRI
-- mark deprecated = true
-- add "replaced by" pointer (property depends on your profile)
-- preserve old label as an exact synonym if appropriate
+When deprecating: keep the IRI, mark `owl:deprecated true`, add a "replaced by" pointer, and preserve the old label as an exact synonym if appropriate.
 
-## Validation commands (repo scripts)
-Preferred: run the repo script:
-- `./tooling/validate.ps1`
+## Validation (repo scripts)
+From the repo root:
+- `python ../tooling/build.py`    — regenerate `../dist/` (reproducible).
+- `python ../tooling/validate.py` — parse + SHACL + competency queries.
 
 Never claim validation passed unless you actually ran the command.

--- a/ontology/modules/hcm-core.ttl
+++ b/ontology/modules/hcm-core.ttl
@@ -1,10 +1,13 @@
 # HCMO / MAPP ontology — hand-authored source module: hcm-core
 # Part of the MAPP (Monitoring and Analytics for Physiological Processes) ontology.
 # Namespace: https://w3id.org/hcmo/ontology/hcm# (+ /bio#, /env#, /obs# per module).
-# Edit modules here; regenerate dist/ artifacts with: python tooling/build.py
+# Contributors are recorded on the owl:Ontology header (dcterms:creator);
+# ORCID IRIs are used where known. Edit modules here; regenerate dist/ with:
+#   python tooling/build.py
 #
 @prefix UNKNOWN: <http://www.owl-ontologies.com/UNKNOWN#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix hcm: <https://w3id.org/hcmo/ontology/hcm#> .
 @prefix hcm-bio: <https://w3id.org/hcmo/ontology/hcm/bio#> .
 @prefix hcm-env: <https://w3id.org/hcmo/ontology/hcm/env#> .
@@ -13,6 +16,7 @@
 @prefix ns: <http://www.owl-ontologies.com/ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <https://schema.org/> .
 @prefix semts: <https://w3id.org/semts/ontology/120#> .
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix time: <http://www.w3.org/2006/time#> .
@@ -143,9 +147,19 @@ sosa:hasFeatureOfInterest a owl:ObjectProperty ;
     rdfs:label "has feature of interest" .
 
 <https://w3id.org/hcmo/ontology/hcm> a owl:Ontology ;
-    dc:creator "Damien/Cyril" ;
     dc:description "Ontology for Monitoring and Analytics for Physiological Processes (MAPP)" ;
     dc:title "MAPP Ontology" ;
+    dcterms:creator [ a schema:Person ;
+            schema:name "Gaoussou Sanou" ],
+        [ a schema:Person ;
+            schema:name "Cyril Gilbert" ],
+        [ a schema:Person ;
+            schema:name "Serge Sonfack" ],
+        [ a schema:Person ;
+            schema:name "Antoine Tofano" ],
+        <https://orcid.org/0000-0002-2923-9790>,
+        <https://orcid.org/0000-0002-9116-6692>,
+        <https://orcid.org/0000-0003-4820-7951> ;
     owl:versionIRI <https://w3id.org/hcmo/ontology/hcm/0.0.1> ;
     owl:versionInfo "0.0.1" ;
     mod:createdWith <https://chowlk.linkeddata.es/> .
@@ -262,6 +276,15 @@ sosa:madeBySensor a owl:ObjectProperty ;
 
 sosa:madeObservation a owl:ObjectProperty ;
     rdfs:label "made observation" .
+
+<https://orcid.org/0000-0002-2923-9790> a schema:Person ;
+    schema:name "Pierre Larmande" .
+
+<https://orcid.org/0000-0002-9116-6692> a schema:Person ;
+    schema:name "Konstantin Todorov" .
+
+<https://orcid.org/0000-0003-4820-7951> a schema:Person ;
+    schema:name "Damien Huzard" .
 
 hcm:QuantityValue a owl:Class ;
     rdfs:label "Quantity Value" .

--- a/tooling/build.py
+++ b/tooling/build.py
@@ -73,6 +73,7 @@ def bind_prefixes(g: Graph, manifest: dict) -> None:
     g.bind("rdfs", RDFS, replace=True)
     g.bind("dc", DC, replace=True)
     g.bind("dcterms", DCTERMS, replace=True)
+    g.bind("schema", Namespace("https://schema.org/"), replace=True)
     g.bind("skos", SKOS, replace=True)
     g.bind("sosa", Namespace("http://www.w3.org/ns/sosa/"), replace=True)
     g.bind("time", Namespace("http://www.w3.org/2006/time#"), replace=True)


### PR DESCRIPTION
- CITATION.cff: list all seven authors. Confirmed ORCIDs added for Huzard (0000-0003-4820-7951), Todorov (0000-0002-9116-6692), and Larmande (0000-0002-2923-9790); ORCID TODO placeholders for Gilbert, Sanou, Sonfack, Tofano (not guessed). Add abstract, license, keywords, repository-code.
- Ontology header (hcm-core): replace informal dc:creator "Damien/Cyril" with structured dcterms:creator using ORCID IRIs (schema:Person names) where known and named placeholders otherwise; bind schema: in build.py; regenerate dist/. Term counts unchanged (32/38/73/4).
- README: professional rewrite focused on the ontology (at-a-glance table, layout, build/validate, consumption, status, contributors, citation). Remove stale blueprint TODO/asset sections referencing files that no longer exist (reference/, ontology/hcm-blueprint.yaml, etc.).
- AGENTS.md (root + ontology/): update to the modules/dist/build.py/ validate.py layout and the hcmo namespace.

build + validate pass; dist/ reproducible.