### PR TITLE
Fix Docs Pages workflow: serialize deploys + auto-enable Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,8 @@
 name: Docs
 
 # Build the WIDOCO HTML documentation and publish it to GitHub Pages.
-# Enable Pages once in repo Settings → Pages → Source: "GitHub Actions".
+# The "Configure Pages" step enables Pages automatically (enablement: true); if
+# your token can't enable it, set Source to "GitHub Actions" in repo Settings → Pages.
 
 on:
   push:
@@ -13,10 +14,11 @@ permissions:
   pages: write
   id-token: write
 
-# One Pages deployment at a time; let a newer run supersede an in-flight one.
+# Allow one concurrent Pages deployment, but let an in-flight production deploy
+# finish rather than cancelling it (GitHub's recommended setting for Pages).
 concurrency:
   group: pages
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -30,6 +32,10 @@ jobs:
         with:
           distribution: temurin
           java-version: '17'
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - name: Install dependencies
         run: pip install -r tooling/requirements.txt
       - name: Build dist artifacts


### PR DESCRIPTION
The WIDOCO docs workflow failed at the deploy step in two ways:

- "Deployment cancelled": cancel-in-progress: true let overlapping Docs runs cancel each other's Pages deployment. Switch to cancel-in-progress: false (GitHub's recommended setting) so an in-flight production deploy is allowed to finish.
- "Ensure GitHub Pages has been enabled" (404): add an actions/configure-pages@v5 step with enablement: true so the workflow turns Pages on itself instead of requiring a manual settings change.