### PR TITLE
Updated the checklist and RDF intake work.

### DIFF
--- a/docs/hcm-systems/FORM-FIELD-MAPPING.md
+++ b/docs/hcm-systems/FORM-FIELD-MAPPING.md
@@ -4,12 +4,27 @@ This document maps the static contribution form to RDF triples for Fuseki intake
 The form JSON remains staging data; the Turtle view is the first canonical ABox
 projection.
 
+## Triple categories
+
+The Turtle projection is organized as ordinary RDF instance data:
+
+- **Instance -> class:** every minted resource gets an explicit `rdf:type`
+  assertion, for example `hcm:System`, `hcm:Sensor`, `hcm:DataProduct`, or
+  `hcm-env:MeasurementSpecification`.
+- **Instance -> instance:** links are emitted with object properties whose object
+  is an IRI, for example `hcm:producedBy`, `hcm:hasHardware`, `hcm:hasSensor`,
+  `hcm:hasSpaceRegion`, `hcm-env:hasMeasurementSpec`, `hcm:captures`,
+  `dcterms:relation`, `dcterms:subject`, and `dcterms:temporal`.
+- **Instance -> data value:** literal fields use datatype or annotation
+  properties, with typed literals where the form can safely parse the value
+  (`xsd:decimal`, `xsd:integer`, `xsd:boolean`).
+
 ## Core submission graph
 
 | Form field / JSON path | RDF target | Triple kind | Notes |
 |---|---|---|---|
 | `identifiers.baseIri` | subject IRI base | IRI policy | Used to mint all submitted resources. |
-| `identifiers.systemId` | `hcm:System` subject | `rdf:type` | Main submitted monitoring-system instance. |
+| `identifiers.systemId` | `hcm:System` subject | `rdf:type` | Main submitted monitoring-system instance. Turtle emits explicit `rdf:type`, not the `a` shorthand. |
 | `system.name` | `rdfs:label` on system | annotation literal | Required for submission validation. |
 | `system.description` | `rdfs:comment` on system | annotation literal | Free-text system description. |
 | `system.type` | `dcterms:type` on system | datatype literal | UI-controlled but not yet a SKOS concept. |
@@ -29,9 +44,11 @@ projection.
 | `sensors[].sensor_type` | sensor `dcterms:type` | datatype literal | Temporary type literal. |
 | `actuators[].actuator_name` | `hcm:Actuator` subject `rdfs:label`; system `hcm:hasActuator` | object + annotation | Optional. |
 | `actuators[].actuator_type` | actuator `dcterms:type` | datatype literal | Temporary type literal. |
-| `dataOutput.formats[]` | `dcterms:format` on system | datatype literal | Repeatable output-format values. |
+| any `dataOutput.*` value | system `dcterms:relation` `hcm:DataProduct` | object | A data-product node is minted only when the submission includes output metadata. |
+| `dataOutput.formats[]` | `dcterms:format` on system; `hcm:hasFileFormat` on data product | datatype literal | Repeatable output-format values. |
 | `dataOutput.datasetLinks[]` | `dcterms:source` on system; `hcm:hasStoragePath` on data product | datatype literal | Also used to populate the `hcm:DataProduct` node. |
 | `contributor.*` | `schema:Person` linked with `dcterms:contributor` | object + schema literals | Submission provenance, not an HCMO domain claim. |
+| any `animals.*` value | system `dcterms:subject` `hcm-bio:Subject` | object | Represents a supported subject profile for the system, not a concrete study animal. |
 | `animals.species` | `hcm-bio:Subject` + `hcm-bio:hasSpecies` | datatype literal | Modeled as a supported subject profile, not a concrete study animal. |
 | `animals.strain` | `hcm-bio:hasStrain` | datatype literal | Free text until a strain vocabulary is chosen. |
 | `animals.sex` | `hcm-bio:hasBiologicalSex` | datatype literal | UI controlled values, still literal. |
@@ -43,7 +60,7 @@ projection.
 | `measurements.parameters[].param_rate` | `hcm:hasSamplingRate` | datatype literal | Free text rate such as `4 Hz` or `30 fps`. |
 | `measurements.behaviors` | `hcm:BehaviorAndPhysiology` + `rdfs:comment`; sensors `hcm:captures` behavior profile | object + annotation | Free-text behavior profile, not controlled behavior terms. |
 | `measurements.circadian` | `hcm:CircadianRhythm` + `rdfs:label` | object + annotation | Linked from the behavior profile. |
-| `recording.duration` | `hcm:ObservationWindow` + `hcm:durationHours` | object + `xsd:decimal` | Emitted only when duration is parseable and greater than 24 hours. |
+| `recording.duration` | system `dcterms:temporal` `hcm:ObservationWindow`; window `hcm:durationHours` | object + `xsd:decimal` | Emitted only when duration is parseable and greater than 24 hours. |
 | `recording.mode` | observation-window `dcterms:type` | datatype literal | UI controlled values, still literal. |
 | `recording.extendable` | `hcm:isExtendable` | datatype literal, `xsd:boolean` | Emitted only for yes/no values. |
 | `dataOutput.sampling` | `hcm:hasSamplingRate` on `hcm:DataProduct` | datatype literal | Free-text rate. |

--- a/docs/hcm-systems/FUSEKI-LOADING.md
+++ b/docs/hcm-systems/FUSEKI-LOADING.md
@@ -16,7 +16,10 @@ python tooling/validate.py
 `dist/hcmo.ttl` is the ontology graph. `docs/hcm-systems/catalog.ttl` is the
 generated sparse catalog graph. User submissions are Turtle files generated from
 the contribution form or curated into the same pattern as
-`examples/user-submission.ttl`.
+`examples/user-submission.ttl`. The DVC worked example has a profile-level ABox at
+`examples/dvc-tecniplast.ttl`; it is source-backed RDF instance data, but it is
+not yet a full SHACL submission because the local profile does not assert cage
+dimensions.
 
 ## Suggested named graphs
 
@@ -27,6 +30,7 @@ submissions can be updated independently:
 |---|---|---|
 | `https://w3id.org/hcmo/graph/ontology` | `dist/hcmo.ttl` | Active HCMO ontology. |
 | `https://w3id.org/hcmo/graph/catalog` | `docs/hcm-systems/catalog.ttl` | Sparse HCM system/product/software/component catalog. |
+| `https://w3id.org/hcmo/graph/examples/dvc-tecniplast` | `examples/dvc-tecniplast.ttl` | Source-backed DVC system profile ABox. |
 | `https://w3id.org/hcmo/graph/submissions` | curated submission `.ttl` files | Complete user-submitted system ABox records. |
 
 ## Example load commands
@@ -39,6 +43,9 @@ tdb2.tdbloader --loc .\fuseki-data\hcmo `
 
 tdb2.tdbloader --loc .\fuseki-data\hcmo `
   --graph=https://w3id.org/hcmo/graph/catalog docs\hcm-systems\catalog.ttl
+
+tdb2.tdbloader --loc .\fuseki-data\hcmo `
+  --graph=https://w3id.org/hcmo/graph/examples/dvc-tecniplast examples\dvc-tecniplast.ttl
 
 tdb2.tdbloader --loc .\fuseki-data\hcmo `
   --graph=https://w3id.org/hcmo/graph/submissions examples\user-submission.ttl

--- a/docs/hcm-systems/README.md
+++ b/docs/hcm-systems/README.md
@@ -40,8 +40,9 @@ hcm-systems/
 
 - **[`systems/DVC_Tecniplast/`](systems/DVC_Tecniplast/)** — Tecniplast DVC®: a
   source-cited system profile, a **real** cohort export, and **synthetic traces that
-  mirror the real CSV schema exactly** (with a deterministic generator). Use it as the
-  template for how a filled-in system folder should look.
+  mirror the real CSV schema exactly** (with a deterministic generator). Its
+  RDF profile graph is [`../../examples/dvc-tecniplast.ttl`](../../examples/dvc-tecniplast.ttl).
+  Use it as the template for how a filled-in system folder should look.
 
 ## How to add a system
 

--- a/docs/hcm-systems/contribute/README.md
+++ b/docs/hcm-systems/contribute/README.md
@@ -12,7 +12,8 @@ are auto-minted from human-friendly answers, and the page renders in light/dark.
 - Live "required fields" progress + missing-field checklist.
 - **Review submission** → a Markdown summary and a JSON payload (`hcmo-contribution/0.1`).
 - **Turtle view** → a Fuseki-ready ABox graph using existing HCMO instance
-  patterns (`rdf:type`, object-property links, and literal values).
+  patterns: explicit `rdf:type` class assertions, instance-to-instance object
+  links, and instance-to-literal data values.
 - **Copy** / **Download** the submission, or **Email to Damien** (opens a pre-filled
   `mailto:` and copies the full details to the clipboard as a paste fallback; the
   contributor attaches their dataset file to that email).
@@ -41,3 +42,6 @@ Submissions arrive by email as Markdown + JSON + Turtle. Drop each into the matc
 `../<system-slug>/` folder (real exports under `datasets/real/`), use the JSON to
 seed the system `README.md`, and load the Turtle into Fuseki when building the
 instance graph.
+
+The field-level RDF projection is documented in
+[`../FORM-FIELD-MAPPING.md`](../FORM-FIELD-MAPPING.md).

--- a/docs/hcm-systems/contribute/index.html
+++ b/docs/hcm-systems/contribute/index.html
@@ -938,13 +938,14 @@
       "@prefix hcm-bio: <https://w3id.org/hcmo/ontology/hcm/bio#> .",
       "@prefix hcm-env: <https://w3id.org/hcmo/ontology/hcm/env#> .",
       "@prefix dcterms: <http://purl.org/dc/terms/> .",
+      "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .",
       "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .",
       "@prefix schema: <https://schema.org/> .",
       "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .",
       ""
     ];
 
-    addTriple(lines, system, "a", "hcm:System");
+    addTriple(lines, system, "rdf:type", "hcm:System");
     addLiteral(lines, system, "rdfs:label", d.system.name);
     addLiteral(lines, system, "rdfs:comment", d.system.description);
     addLiteral(lines, system, "dcterms:type", d.system.type);
@@ -962,39 +963,39 @@
     d.dataOutput.formats.forEach(function (f) { addLiteral(lines, system, "dcterms:format", f); });
     d.dataOutput.datasetLinks.forEach(function (link) { addLiteral(lines, system, "dcterms:source", link); });
 
-    addTriple(lines, supplier, "a", "hcm:Supplier");
+    addTriple(lines, supplier, "rdf:type", "hcm:Supplier");
     addLiteral(lines, supplier, "rdfs:label", d.system.vendor);
 
-    addTriple(lines, hardware, "a", "hcm:Hardware");
+    addTriple(lines, hardware, "rdf:type", "hcm:Hardware");
     addLiteral(lines, hardware, "rdfs:label", d.hardwareSoftware.hardware);
     addLiteral(lines, hardware, "rdfs:comment", d.hardwareSoftware.interoperability);
 
-    addTriple(lines, software, "a", "hcm:Software");
+    addTriple(lines, software, "rdf:type", "hcm:Software");
     addLiteral(lines, software, "rdfs:label", d.hardwareSoftware.software);
 
-    addTriple(lines, enclosure, "a", "hcm:Enclosure");
+    addTriple(lines, enclosure, "rdf:type", "hcm:Enclosure");
     addLiteral(lines, enclosure, "dcterms:type", d.enclosure.type);
     addLiteral(lines, enclosure, "rdfs:comment", d.enclosure.fit);
     addTriple(lines, enclosure, "hcm:hasSpaceRegion", physicalSpace);
 
-    addTriple(lines, physicalSpace, "a", "hcm:PhysicalSpace");
+    addTriple(lines, physicalSpace, "rdf:type", "hcm:PhysicalSpace");
     addLiteral(lines, physicalSpace, "rdfs:label", (d.system.name || "system") + " enclosure space");
     addTriple(lines, physicalSpace, "hcm:hasDimensions", dimensions);
 
-    addTriple(lines, dimensions, "a", "hcm:Dimensions");
+    addTriple(lines, dimensions, "rdf:type", "hcm:Dimensions");
     addLiteral(lines, dimensions, "hcm:width", d.enclosure.width, "xsd:decimal");
     addLiteral(lines, dimensions, "hcm:length", d.enclosure.length, "xsd:decimal");
     addLiteral(lines, dimensions, "hcm:height", d.enclosure.height, "xsd:decimal");
     addLiteral(lines, dimensions, "hcm:unit", d.enclosure.unit);
 
-    addTriple(lines, contributor, "a", "schema:Person");
+    addTriple(lines, contributor, "rdf:type", "schema:Person");
     addLiteral(lines, contributor, "schema:name", d.contributor.name);
     addLiteral(lines, contributor, "schema:email", d.contributor.email);
     addLiteral(lines, contributor, "schema:affiliation", d.contributor.organization);
     addLiteral(lines, contributor, "schema:roleName", d.contributor.role);
 
     if (hasAnyValue(d.animals)) {
-      addTriple(lines, subject, "a", "hcm-bio:Subject");
+      addTriple(lines, subject, "rdf:type", "hcm-bio:Subject");
       addLiteral(lines, subject, "rdfs:label", (d.system.name || "system") + " supported subject profile");
       addLiteral(lines, subject, "hcm-bio:hasSpecies", d.animals.species);
       addLiteral(lines, subject, "hcm-bio:hasStrain", d.animals.strain);
@@ -1005,12 +1006,12 @@
     }
 
     if (d.measurements.behaviors || d.measurements.circadian) {
-      addTriple(lines, behavior, "a", "hcm:BehaviorAndPhysiology");
+      addTriple(lines, behavior, "rdf:type", "hcm:BehaviorAndPhysiology");
       addLiteral(lines, behavior, "rdfs:label", (d.system.name || "system") + " behavior profile");
       addLiteral(lines, behavior, "rdfs:comment", d.measurements.behaviors);
       if (d.measurements.circadian) {
         addTriple(lines, behavior, "hcm:hasCircadianRhythm", circadian);
-        addTriple(lines, circadian, "a", "hcm:CircadianRhythm");
+        addTriple(lines, circadian, "rdf:type", "hcm:CircadianRhythm");
         addLiteral(lines, circadian, "rdfs:label", d.measurements.circadian);
       }
     }
@@ -1019,7 +1020,7 @@
       if (!param.param_name && !param.param_unit && !param.param_rate) return;
       var node = iri(base, "measurement-spec-" + (index + 1) + "-" + slug(param.param_name || "parameter"));
       addTriple(lines, system, "hcm-env:hasMeasurementSpec", node);
-      addTriple(lines, node, "a", "hcm-env:MeasurementSpecification");
+      addTriple(lines, node, "rdf:type", "hcm-env:MeasurementSpecification");
       addLiteral(lines, node, "rdfs:label", param.param_name);
       addLiteral(lines, node, "hcm-env:hasUnit", param.param_unit);
       addLiteral(lines, node, "hcm:hasSamplingRate", param.param_rate);
@@ -1028,7 +1029,7 @@
     var durationHours = parseDurationHours(d.recording.duration);
     if (durationHours && durationHours > 24) {
       addTriple(lines, system, "dcterms:temporal", observationWindow);
-      addTriple(lines, observationWindow, "a", "hcm:ObservationWindow");
+      addTriple(lines, observationWindow, "rdf:type", "hcm:ObservationWindow");
       addLiteral(lines, observationWindow, "rdfs:label", (d.system.name || "system") + " observation window");
       addLiteral(lines, observationWindow, "hcm:durationHours", String(durationHours), "xsd:decimal");
       addLiteral(lines, observationWindow, "hcm:isExtendable", booleanLiteral(d.recording.extendable), "xsd:boolean");
@@ -1036,7 +1037,7 @@
     }
 
     if (d.dataOutput.sampling || d.dataOutput.volume || d.dataOutput.schema || d.dataOutput.license || d.dataOutput.formats.length || d.dataOutput.datasetLinks.length) {
-      addTriple(lines, dataProduct, "a", "hcm:DataProduct");
+      addTriple(lines, dataProduct, "rdf:type", "hcm:DataProduct");
       addLiteral(lines, dataProduct, "rdfs:label", (d.system.name || "system") + " data output");
       d.dataOutput.formats.forEach(function (f) { addLiteral(lines, dataProduct, "hcm:hasFileFormat", f); });
       addLiteral(lines, dataProduct, "hcm:hasSamplingRate", d.dataOutput.sampling);
@@ -1049,7 +1050,7 @@
     d.sensors.forEach(function (sensor, index) {
       var node = iri(base, "sensor-" + (index + 1) + "-" + slug(sensor.sensor_name || "sensor"));
       addTriple(lines, system, "hcm:hasSensor", node);
-      addTriple(lines, node, "a", "hcm:Sensor");
+      addTriple(lines, node, "rdf:type", "hcm:Sensor");
       addLiteral(lines, node, "rdfs:label", sensor.sensor_name);
       addLiteral(lines, node, "dcterms:type", sensor.sensor_type);
       if (d.measurements.behaviors || d.measurements.circadian) addTriple(lines, node, "hcm:captures", behavior);
@@ -1057,7 +1058,7 @@
     d.actuators.forEach(function (actuator, index) {
       var node = iri(base, "actuator-" + (index + 1) + "-" + slug(actuator.actuator_name || "actuator"));
       addTriple(lines, system, "hcm:hasActuator", node);
-      addTriple(lines, node, "a", "hcm:Actuator");
+      addTriple(lines, node, "rdf:type", "hcm:Actuator");
       addLiteral(lines, node, "rdfs:label", actuator.actuator_name);
       addLiteral(lines, node, "dcterms:type", actuator.actuator_type);
     });

--- a/docs/hcm-systems/systems/DVC_Tecniplast/README.md
+++ b/docs/hcm-systems/systems/DVC_Tecniplast/README.md
@@ -21,6 +21,8 @@ schema exactly.
 DVC_Tecniplast/
   README.md                    ← this file
   dvc-system-profile.md        ← full source-cited profile (9 sections + Sources)
+  ../../../../examples/dvc-tecniplast.ttl
+                               ← profile-level RDF ABox graph
   datasets/
     real/                      ← real cohort-7623 export + data dictionary
       Cohort7623_animal_loc__index_smoothed.csv
@@ -39,6 +41,11 @@ DVC_Tecniplast/
   citations.
 - **Real data + schema:** [`datasets/real/README.md`](datasets/real/README.md).
 - **Mock traces + generator:** [`datasets/mock/README.md`](datasets/mock/README.md).
+- **RDF ABox profile:** [`../../../../examples/dvc-tecniplast.ttl`](../../../../examples/dvc-tecniplast.ttl)
+  organizes the DVC example as explicit `rdf:type` assertions,
+  instance-to-instance object-property links, and instance-to-literal data values.
+  It intentionally does not assert enclosure dimensions because they are not
+  recorded in this local profile.
 
 ## HCMO mapping (highlights)
 

--- a/docs/paper/CHECKLIST-CYRIL.md
+++ b/docs/paper/CHECKLIST-CYRIL.md
@@ -8,18 +8,19 @@
 > Google Sheet directly (read-only access), so copy the **Statut / Lien-preuve /
 > Commentaire** columns below back into the sheet.
 >
-> **Statut legend:** ✅ Fait · 🟡 En cours · ⛔ Bloqué (needs clean V1 = T0) · ⬜ À faire
-> **Last synced:** 2026-07-03 (branch `claude/resource-paper-draft`)
+> **Statut legend:** ✅ Fait · 🟡 En cours · ⏸ Reporté · ⛔ Bloqué (needs clean V1 = T0) · ⬜ À faire
+> **Last synced:** 2026-07-09 (branch `main`)
 
 ## Progress snapshot
 | Indicateur | Valeur |
 |---|---|
 | Total | 44 |
-| ✅ Fait | 23 |
+| ✅ Fait | 25 |
 | 🟡 En cours | 6 |
-| ⛔ Bloqué (T0) | 8 |
-| ⬜ À faire | 7 |
-| Obligatoires restantes (non-Fait) | ~20 |
+| ⏸ Reporté | 1 |
+| ⛔ Bloqué (T0) | 4 |
+| ⬜ À faire | 8 |
+| Obligatoires restantes (non-Fait) | ~16 |
 
 ## Items
 
@@ -34,24 +35,24 @@
 | 7 | Related work | 5–10 resource papers d'ontologies comparables | Oui | ✅ | `docs/paper/notes/resource-papers/README.md` | 5 resource papers comparables identifiés avec source et critères de comparaison pour HCMO : metadata, availability, figures, CQ/SPARQL, évaluation. |
 | 8 | Related work | Guidelines / best practices publication ontologie | Oui | ✅ | `CALL-REQUIREMENTS.md`, `references.bib` | WIDOCO, OOPS!, FAIR, w3id, Zenodo, LOT/SAMOD. |
 | 9 | Related work | Tableau critères ESWC vs ISWC | Oui | ✅ | `README.md`, `CALL-REQUIREMENTS.md` | Format, anonymat, pages, availability. |
-| 10 | Ontologie | Stabiliser classes & propriétés centrales | Oui | 🟡 | `ontology/v2/`, `docs/paper/MODULE-MAP.md` | v2 5 modules construit et nettoyé légèrement; reste à promouvoir officiellement puis traiter placeholders/unités/définitions. |
+| 10 | Ontologie | Stabiliser classes & propriétés centrales | Oui | 🟡 | `ontology/v2/`, `docs/paper/MODULE-MAP.md` | v2 5 modules construit et placeholders nettoyés; reste à promouvoir officiellement puis traiter unités/définitions. |
 | 11 | Ontologie | Labels + commentaires entités principales | Oui | ⛔ | `AUDIT.md` | **0 `rdfs:comment`** dans le dépôt actuel → V1. |
-| 12 | Ontologie | Vérifier modules Turtle/OWL exportés | Oui | 🟡 | `ontology/v2/README.md`, `ontology/v2/hcmo-v2-merged.ttl` | Modules v2 + merged TTL parsés avec rdflib; live build/CI pas encore repointés. |
-| 13 | Ontologie | Nettoyer termes Chowlk temporaires | Oui | 🟢 | `docs/paper/PLACEHOLDER-MAP.md`, `ontology/v2/modules/hcm-placeholders.ttl` | v2 active placeholders reduced to 0 on the review branch. Final cleanup should be reviewed by co-authors before promotion. |
-| 14 | Ontologie | Exemples d'instances représentatifs | Oui | ⛔ | `sections/03-requirements.md` | Scénario HCM complet; ABox synthétiques après T0. |
+| 12 | Ontologie | Vérifier modules Turtle/OWL exportés | Oui | ✅ | `ontology/v2/README.md`, `ontology/v2/hcmo-v2-merged-clean.owl`, `docs/paper/PROTEGE-REASONER.md` | Modules v2 + clean OWL parsés; HermiT passe avec 32 classes et 0 classe incohérente. Live build/CI à repointer à la promotion. |
+| 13 | Ontologie | Nettoyer termes Chowlk temporaires | Oui | ✅ | `docs/paper/PLACEHOLDER-MAP.md`, `ontology/v2/modules/hcm-placeholders.ttl` | Placeholders actifs v2 réduits à 0; cleanup final appliqué et documenté. Validation co-auteurs encore utile avant promotion. |
+| 14 | Ontologie | Exemples d'instances représentatifs | Oui | 🟡 | `examples/user-submission.ttl`, `examples/dvc-tecniplast.ttl`, `docs/hcm-systems/FORM-FIELD-MAPPING.md` | Formulaire + DVC organisés en triples RDF: `rdf:type`, liens instance-instance, et valeurs littérales. Il reste à produire les exemples SHACL v2 complets après promotion. |
 | 15 | Ontologie | Requêtes SPARQL des competency questions | Oui | ⛔ | `sections/03-requirements.md` | CQ1–CQ6 définies; requêtes après T0 (renvoient 0 actuellement). |
 | 16 | Ontologie | SHACL valides/invalides | Oui | ⏸ | `docs/paper/PROTEGE-REASONER.md` | Reporté après décision de réunion: d'abord raisonneur OWL dans Protégé sur v2; SHACL seulement après gel/promotion des termes v2. |
-| 17 | Ontologie | Lancer OOPS! + noter problèmes | Oui | ⛔ | — | Bloqué T0. |
+| 17 | Ontologie | Lancer OOPS! + FOOPS! FAIR ontology assessment + noter problèmes | Oui | ⬜ | `sections/06-evaluation.md` | À lancer sur le clean v2 ou la release promue; archiver scores et actions correctives. |
 | 18 | Évaluation | Définir les competency questions de l'article | Oui | ✅ | `sections/03-requirements.md` | CQ1–CQ6 + mapping R1–R8. |
 | 19 | Évaluation | Chaque requête répond à une CQ | Oui | ⛔ | — | Bloqué T0 (besoin de la V1 + requêtes). |
-| 20 | Évaluation | Bilan OOPS!/SHACL/WIDOCO | Oui | 🟡 | `sections/06-evaluation.md`, `docs/paper/PROTEGE-REASONER.md` | WIDOCO ✅; prochaine preuve qualité = raisonneur Protégé sur v2. SHACL reporté. |
+| 20 | Évaluation | Bilan OOPS!/FOOPS!/SHACL/WIDOCO/HermiT | Oui | 🟡 | `sections/06-evaluation.md`, `docs/paper/PROTEGE-REASONER.md` | WIDOCO ✅; HermiT ✅; OOPS! + FOOPS! à exécuter; SHACL reporté jusqu'au gel/promotion des termes v2. |
 | 21 | Ontologie | Documentation WIDOCO | Oui | ✅ | `README.md` → <https://dhuzard.github.io/HCMO/index-en.html> | Lien ajouté au README. |
 | 22 | Availability | Dépôt GitHub propre & compréhensible | Oui | 🟡 | `README.md`, `ontology/v2/README.md`, `docs/paper/TODO.md` | README enrichi; v2 documentée; nettoyage global et promotion restent en cours. |
 | 23 | Availability | Release versionnée figée | Oui | ⬜ | `TODO.md` (T9) | À cadrer sur la version citée. |
 | 24 | Availability | DOI Zenodo | Oui | ✅ | `CITATION.cff` → 10.5281/zenodo.18925285 | Existe; à refigers sur la release du papier (T9). |
 | 25 | Availability | Vérifier la licence | Oui | ✅ | `LICENSE`, `README.md` | CC BY 4.0 (fichier vérifié). ⚠ **Consentement des co-auteurs à confirmer** (CC BY 4.0 vs CC0) — voir OPEN-QUESTIONS Q19 / TODO T23b. |
 | 26 | Availability | CITATION.cff | Oui | ✅ | `CITATION.cff` | Présent + ORCIDs ajoutés. |
-| 27 | Availability | Namespace persistant w3id | Oui | ✅ | <https://github.com/perma-id/w3id.org/pull/6261>, <https://w3id.org/hcmo/ontology/hcm> | PR w3id merged le 2026-06-30 ; namespace HCMO accepté. À vérifier ensuite avec la release finale. |
+| 27 | Availability | Namespace persistant w3id | Oui | 🟡 | <https://github.com/perma-id/w3id.org/pull/6261>, <https://w3id.org/hcmo/ontology/hcm> | Namespace HCMO live depuis le 2026-06-30. Follow-up ajouté: mettre à jour le w3id pour la version v2/release promue, sans changer l'IRI de base. |
 | 28 | Availability | README : comment utiliser l'ontologie | Oui | ✅ | `README.md` | Quickstart + "Consuming the ontology". |
 | 29 | Availability | Release/doc/DOI = même version | Oui | ⬜ | `TODO.md` (T9) | À faire au moment de la release. |
 | 30 | Availability | Section Availability prête à coller | Oui | ✅ | `sections/05-availability.md`, `metadata/resource-metadata.md` | GitHub/DOI/licence/docs/examples/queries. |
@@ -74,11 +75,11 @@
 Abstract + §1 Introduction + §2 Related work + §3 Requirements + §5
 Engineering/Availability + §7 Impact + §8 Conclusion are **drafted** in
 `docs/paper/sections/`. **§4 Resource description** and **§6 Evaluation** are the
-only sections still missing — both **blocked on the clean V1 (T0)**.
+only sections still incomplete; §6 now has HermiT evidence and OOPS!/FOOPS!
+tracking, while final SHACL/CQ claims still depend on v2 promotion.
 
-## The one blocker driving most ⛔ items
-Items **11, 14–17, 19, 42** still wait on the promoted clean ontology (see
-`ontology/v2/` and `AUDIT.md`). Item **10** has moved from blocked to in progress
-because the v2 modular draft is now the working artifact; item **13** is also in
-progress via `PLACEHOLDER-MAP.md`. Item **27 (w3id)** is done; **23/29 (release
-alignment)** proceed after promotion.
+## The remaining blocker
+Items **11, 15, 19, 42** still wait on the promoted clean ontology and the
+paper-ready v2 release alignment. Item **13** is done, HermiT evidence is
+recorded, and item **17** now explicitly includes **FOOPS!** for FAIR ontology
+assessment. Item **27 (w3id)** is live but reopened as a v2 release follow-up.

--- a/docs/paper/TODO.md
+++ b/docs/paper/TODO.md
@@ -1,7 +1,7 @@
 # HCMO Resource Paper — TODO & change tracking
 
 **Status legend:** ☐ todo · ◐ in progress · ☑ done · ⚠ blocked
-**Last updated:** 2026-07-03
+**Last updated:** 2026-07-09
 
 This is the single source of truth for paper progress. Update the **status**
 column and append to the **Change log** whenever something moves.
@@ -15,6 +15,7 @@ column and append to the **Change log** whenever something moves.
 | T0 | **Clean ontology artifact for paper/release** — v2 draft now exists in `ontology/v2/`; official promotion still waits on co-author sign-off and cleanup gates. | Damien/Cyril/Codex | ◐ | `ontology/v2/` is the reviewed path forward. Live `ontology/modules/`, `dist/`, shapes/examples/queries still point to the old export until promotion. |
 | T1 | ~~Lock venue~~ → **ESWC 2027 Resources Track, 15 pp** (HITL R1) | — | ☑ | Re-confirm dates/template when CfP opens. |
 | T2 | ~~Create the w3id PURL redirect~~ → **live**: `https://w3id.org/hcmo/ontology/hcm#` resolves (303 → docs site) | — | ☑ | **Availability hard gate cleared.** [w3id PR #6261](https://github.com/perma-id/w3id.org/pull/6261) merged 2026-06-30; verified 2026-07-03. Re-check with the paper-matching release (T9). |
+| T2b | **Update w3id for the promoted v2 ontology** while keeping the base ontology IRI stable. | — | ☐ | After v2 promotion/release, update the perma-id redirect/content negotiation targets to the v2 documentation and distributions; do not re-mint term IRIs. |
 | T3 | Create Overleaf project from **LNCS** template; mirror `sections/` | — | ☐ | Keep authors **named** (single-anonymous). |
 | T3b | **Re-modularise** to the **DECIDED** R5 shape (2026-07-03): **5 modules — `hcm` core = enclosure only · `bio` · `obs` (observations + results) · `env` · `tech`**. `HousingAssignment` → bio (out of obs); `EnclosureDimensions` → core; all result/value classes → obs; `Sensor/Hardware/Software/TimeSeries` → new `tech` (`…/hcm/tech#`). Supersedes bio/housing/env/tech. | — | ◐ | **Draft built and lightly cleaned in `ontology/v2/`** (parallel, not yet wired to build/CI). Commits `d1fd21e` + `3fc46a4` apply co-author-review cleanup and figure-label alignment. Awaiting Damien validation before replacing `ontology/modules/`. Spec: `docs/paper/MODULE-MAP.md`. |
 | T3c | **Decide which module owns the bio↔obs linking properties** (Subject→observation vs Observation→subject). The two modules are mutually dependent; **accept the bio/obs cycle for V1 knowingly** (harmless in the merged graph; blocks strict `owl:imports` layering only). | — | ☑ | Decision applied in v2 and documented in `docs/ARCHITECTURE.md`/`MODEL.md`: subject-to-observation convenience links stay in `bio`; observation-to-subject semantics use SOSA `hasFeatureOfInterest` in `obs`. |
@@ -31,7 +32,7 @@ column and append to the **Change log** whenever something moves.
 | T6b | **Host a public SPARQL endpoint** (HITL R3) | ☐ | Strongest availability story; depends on T0. |
 | T7 | Write **lab-maintained** governance/versioning policy (Huzard team, GitHub, SemVer+versionIRI; TEATIME = feedback channel) | ☐ | HITL R3. Feeds §7. |
 | T7b | **Drop MAPP branding** in paper docs (done) + reconcile repo branding (`hcmo.yaml` title, README) separately | ◐ | HCMO branding applied to v2 ontology header and `version_rapport` figure sources. Live manifest/README/dist still need reconciliation at promotion. |
-| T8 | Run **quality evaluation**: OOPS!, FOOPS! (FAIR), reasoner (HermiT/ELK), pySHACL, CQ results — archive reports | ◐ | Protege 5.6.9 opens `ontology/v2/hcmo-v2-merged-clean.owl`; HermiT command-line check passes with 32 classes and 0 inconsistent classes. SHACL deferred. See `docs/paper/PROTEGE-REASONER.md`. |
+| T8 | Run **quality evaluation**: OOPS!, FOOPS! (FAIR), reasoner (HermiT/ELK), pySHACL, CQ results — archive reports | ◐ | Protege 5.6.9 opens `ontology/v2/hcmo-v2-merged-clean.owl`; HermiT command-line check passes with 32 classes and 0 inconsistent classes. OOPS! + FOOPS! reports still pending; SHACL/CQ deferred until v2 promotion. See `docs/paper/PROTEGE-REASONER.md`. |
 | T9 | Cut a **tagged release** (e.g. `v0.x`) + refreshed Zenodo DOI matching the paper | ☐ | Canonical citation. |
 
 ## Phase 2 — Write the paper
@@ -67,6 +68,7 @@ column and append to the **Change log** whenever something moves.
 
 | Date | Change | By |
 |------|--------|----|
+| 2026-07-09 | **Checklist/RDF intake update** — mirrored the merged HermiT + placeholder status, added FOOPS! and the w3id-v2 follow-up to tracking, made form Turtle emit explicit `rdf:type`, and added a DVC profile ABox organized as class, object-property, and literal triples. | Codex |
 | 2026-07-09 | **Applied final v2 placeholder cleanup** — replaced the remaining active v2 `UNKNOWN:` placeholders with proposed module terms or existing relations, regenerated v2 merged/clean artifacts, and confirmed HermiT still reports 0 inconsistent classes. | Codex |
 | 2026-07-09 | **Placeholder decision proposal** — expanded `PLACEHOLDER-MAP.md` with recommended actions for the 7 remaining v2 `UNKNOWN:` placeholders, including confidence levels and rationale grounded in v2 modules and legacy HCMO precedent. | Codex |
 | 2026-07-09 | **Figure placeholder alignment** — refreshed `version_rapport.drawio` and `.drawio.xml` labels again after the final cleanup, so the diagram no longer presents active v2 `UNKNOWN:` placeholders. | Codex |

--- a/docs/paper/sections/06-evaluation.md
+++ b/docs/paper/sections/06-evaluation.md
@@ -2,9 +2,9 @@
 
 - Pitfall scan: OOPS! (report + how pitfalls were addressed).
 - FAIRness: FOOPS! score.
-- Logical quality: Protege reasoner pass (ELK/HermiT) on
-  `ontology/v2/hcmo-v2-merged.ttl` — consistency, no unsatisfiable classes, no
-  unintended inferred placements. See `docs/paper/PROTEGE-REASONER.md`.
+- Logical quality: Protege/HermiT pass on
+  `ontology/v2/hcmo-v2-merged-clean.owl` — 32 classes loaded, 0 inconsistent
+  classes, no `UNKNOWN:` IRIs. See `docs/paper/PROTEGE-REASONER.md`.
 - Data validation: SHACL is deferred until the v2 terms are frozen/promoted;
   current `shapes/` and `examples/` still target the legacy/live term set.
 - Competency-question results: each CQ → answer over the merged graph (T6).

--- a/examples/dvc-tecniplast.ttl
+++ b/examples/dvc-tecniplast.ttl
@@ -1,0 +1,149 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dvc: <https://w3id.org/hcmo/id/dvc-tecniplast/> .
+@prefix hcm: <https://w3id.org/hcmo/ontology/hcm#> .
+@prefix hcm-bio: <https://w3id.org/hcmo/ontology/hcm/bio#> .
+@prefix hcm-env: <https://w3id.org/hcmo/ontology/hcm/env#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Instance-class triples: each resource is explicitly typed with rdf:type.
+
+dvc:system rdf:type hcm:System .
+dvc:tecniplast rdf:type hcm:Supplier .
+dvc:rack-controller rdf:type hcm:Hardware .
+dvc:dvc-analytics rdf:type hcm:Software .
+dvc:cage rdf:type hcm:Enclosure .
+dvc:capacitive-electrode-board rdf:type hcm:Sensor .
+dvc:rack-environment-monitor rdf:type hcm:Sensor .
+dvc:activity-profile rdf:type hcm:BehaviorAndPhysiology .
+dvc:circadian-profile rdf:type hcm:CircadianRhythm .
+dvc:seven-day-window rdf:type hcm:ObservationWindow .
+dvc:data-product rdf:type hcm:DataProduct .
+dvc:mouse-subject-profile rdf:type hcm-bio:Subject .
+dvc:group-housed-cage-profile rdf:type hcm-bio:ExperimentalGroup .
+dvc:measurement-activation-density rdf:type hcm-env:MeasurementSpecification .
+dvc:measurement-bedding-status rdf:type hcm-env:MeasurementSpecification .
+dvc:measurement-rack-temperature rdf:type hcm-env:MeasurementSpecification .
+dvc:measurement-rack-humidity rdf:type hcm-env:MeasurementSpecification .
+
+# Instance-instance triples: object-property links between resources.
+
+dvc:system
+  hcm:producedBy dvc:tecniplast ;
+  hcm:hasHardware dvc:rack-controller ;
+  hcm:hasSoftware dvc:dvc-analytics ;
+  hcm:hasEnclosure dvc:cage ;
+  hcm:hasSensor dvc:capacitive-electrode-board,
+    dvc:rack-environment-monitor ;
+  hcm-env:hasMeasurementSpec dvc:measurement-activation-density,
+    dvc:measurement-bedding-status,
+    dvc:measurement-rack-temperature,
+    dvc:measurement-rack-humidity ;
+  dcterms:relation dvc:data-product ;
+  dcterms:subject dvc:mouse-subject-profile,
+    dvc:group-housed-cage-profile ;
+  dcterms:temporal dvc:seven-day-window .
+
+dvc:rack-controller hcm:communicatesWith dvc:dvc-analytics .
+
+dvc:capacitive-electrode-board
+  hcm:captures dvc:activity-profile ;
+  dcterms:relation dvc:measurement-activation-density,
+    dvc:measurement-bedding-status .
+
+dvc:rack-environment-monitor
+  dcterms:relation dvc:measurement-rack-temperature,
+    dvc:measurement-rack-humidity .
+
+dvc:activity-profile
+  hcm:hasCircadianRhythm dvc:circadian-profile ;
+  hcm:extendsEnoughToCapture dvc:seven-day-window .
+
+# Instance-data triples: literals carried by data or annotation properties.
+
+dvc:system
+  rdfs:label "DVC (Digital Ventilated Cage)" ;
+  rdfs:comment "Profile-level HCMO ABox for the Tecniplast DVC reference example; concrete enclosure dimensions are not asserted because they are not recorded in the local DVC profile." ;
+  dcterms:type "Electrical-capacitance home-cage monitoring system" ;
+  dcterms:source "https://doi.org/10.1016/j.heliyon.2019.e01454" ;
+  dcterms:source "https://doi.org/10.1038/s41598-025-87530-6" ;
+  hcm:hasDescription "Capacitive electrode array under an IVC cage; DVC Analytics exports activity, bedding status, and rack environment measurements." .
+
+dvc:tecniplast
+  rdfs:label "Tecniplast S.p.A." .
+
+dvc:rack-controller
+  rdfs:label "DVC rack controller" ;
+  rdfs:comment "Hardware layer coordinating cage-level DVC sensor boards." .
+
+dvc:dvc-analytics
+  rdfs:label "DVC Analytics" ;
+  rdfs:comment "Cloud software used for acquisition, visualization, export, and proprietary ALI/BSI derivation." .
+
+dvc:cage
+  rdfs:label "DVC monitored IVC cage" ;
+  rdfs:comment "Standard IVC cage monitored by an externally mounted DVC sensing board; dimensions are intentionally not asserted in this profile graph." ;
+  dcterms:type "Individually ventilated cage with external DVC board" .
+
+dvc:capacitive-electrode-board
+  rdfs:label "DVC capacitive electrode board" ;
+  dcterms:type "12-electrode capacitive sensing board" ;
+  hcm:hasSamplingRate "4 Hz" ;
+  hcm:hasDescription "Capacitance-based cage-level sensing board mounted under the cage." .
+
+dvc:rack-environment-monitor
+  rdfs:label "DVC rack environmental monitor" ;
+  dcterms:type "Rack temperature and relative-humidity monitor" ;
+  hcm:hasDescription "Rack-level environmental context channel." .
+
+dvc:activity-profile
+  rdfs:label "DVC activity and locomotion profile" ;
+  rdfs:comment "Cage-level activity profile including activation density and derived Animal Locomotion Index outputs." .
+
+dvc:circadian-profile
+  rdfs:label "DVC circadian activity profile" ;
+  rdfs:comment "Circadian summaries derived from DVC activity exports." .
+
+dvc:seven-day-window
+  rdfs:label "DVC mock-trace observation window" ;
+  hcm:durationHours "168"^^xsd:decimal ;
+  hcm:isExtendable "true"^^xsd:boolean ;
+  dcterms:type "Continuous 7-day mock trace window" .
+
+dvc:data-product
+  rdfs:label "DVC CSV export data product" ;
+  rdfs:comment "Profile graph for the real cohort export and synthetic mock traces in the DVC example folder." ;
+  hcm:hasFileFormat "CSV" ;
+  hcm:hasSamplingRate "4 Hz raw stream; 1 minute binned example exports" ;
+  hcm:hasStoragePath "docs/hcm-systems/systems/DVC_Tecniplast/datasets/real/Cohort7623_animal_loc__index_smoothed.csv" ;
+  hcm:hasStoragePath "docs/hcm-systems/systems/DVC_Tecniplast/datasets/mock/mock_B6_M_animal_loc__index_smoothed.csv" .
+
+dvc:mouse-subject-profile
+  rdfs:label "DVC supported mouse subject profile" ;
+  rdfs:comment "DVC literature in the local profile supports mouse use; individual attribution is direct only for single-housed cages." ;
+  hcm-bio:hasSpecies "Mus musculus" .
+
+dvc:group-housed-cage-profile
+  rdfs:label "DVC group-housed cage profile" ;
+  rdfs:comment "Group-housed DVC signals are cage-level aggregate measurements rather than native per-animal tracks." .
+
+dvc:measurement-activation-density
+  rdfs:label "Activation density / Animal Locomotion Index" ;
+  hcm-env:hasUnit "percent" ;
+  hcm:hasSamplingRate "4 Hz raw; binned in CSV exports" .
+
+dvc:measurement-bedding-status
+  rdfs:label "Bedding Status Index" ;
+  hcm-env:hasUnit "arbitrary unit" ;
+  hcm:hasSamplingRate "binned in CSV exports" .
+
+dvc:measurement-rack-temperature
+  rdfs:label "Rack temperature" ;
+  hcm-env:hasUnit "degree Celsius" ;
+  hcm:hasSamplingRate "continuous; exact export rate not asserted" .
+
+dvc:measurement-rack-humidity
+  rdfs:label "Rack relative humidity" ;
+  hcm-env:hasUnit "percent relative humidity" ;
+  hcm:hasSamplingRate "continuous; exact export rate not asserted" .

--- a/examples/user-submission.ttl
+++ b/examples/user-submission.ttl
@@ -3,11 +3,12 @@
 @prefix hcm: <https://w3id.org/hcmo/ontology/hcm#> .
 @prefix hcm-bio: <https://w3id.org/hcmo/ontology/hcm/bio#> .
 @prefix hcm-env: <https://w3id.org/hcmo/ontology/hcm/env#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <https://schema.org/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-ex:system-example-hcm a hcm:System ;
+ex:system-example-hcm rdf:type hcm:System ;
   rdfs:label "Example HCM system submission" ;
   rdfs:comment "Example generated from the HCMO contribution form pattern." ;
   dcterms:contributor ex:contributor-jane-doe ;
@@ -24,35 +25,35 @@ ex:system-example-hcm a hcm:System ;
   hcm-env:hasMeasurementSpec ex:measurement-spec-activity ;
   hcm:producedBy ex:supplier-example-vendor .
 
-ex:supplier-example-vendor a hcm:Supplier ;
+ex:supplier-example-vendor rdf:type hcm:Supplier ;
   rdfs:label "Example Vendor" .
 
-ex:hw-example-unit a hcm:Hardware ;
+ex:hw-example-unit rdf:type hcm:Hardware ;
   rdfs:label "Example control unit" .
 
-ex:sw-example-app a hcm:Software ;
+ex:sw-example-app rdf:type hcm:Software ;
   rdfs:label "Example analytics app" .
 
-ex:enclosure-example-hcm a hcm:Enclosure ;
+ex:enclosure-example-hcm rdf:type hcm:Enclosure ;
   dcterms:type "Retrofit module for standard cage" ;
   hcm:hasSpaceRegion ex:space-example-hcm .
 
-ex:space-example-hcm a hcm:PhysicalSpace ;
+ex:space-example-hcm rdf:type hcm:PhysicalSpace ;
   rdfs:label "Example HCM system submission enclosure space" ;
   hcm:hasDimensions ex:dimensions-example-hcm .
 
-ex:dimensions-example-hcm a hcm:Dimensions ;
+ex:dimensions-example-hcm rdf:type hcm:Dimensions ;
   hcm:height "20.0"^^xsd:decimal ;
   hcm:length "45.0"^^xsd:decimal ;
   hcm:unit "cm" ;
   hcm:width "30.0"^^xsd:decimal .
 
-ex:sensor-ir-camera a hcm:Sensor ;
+ex:sensor-ir-camera rdf:type hcm:Sensor ;
   rdfs:label "IR camera" ;
   dcterms:type "Infrared video sensor" ;
   hcm:captures ex:behavior-profile-example-hcm .
 
-ex:subject-profile-example-hcm a hcm-bio:Subject ;
+ex:subject-profile-example-hcm rdf:type hcm-bio:Subject ;
   rdfs:label "Example HCM system submission supported subject profile" ;
   rdfs:comment "Group housed" ;
   dcterms:extent "12 cages" ;
@@ -61,26 +62,26 @@ ex:subject-profile-example-hcm a hcm-bio:Subject ;
   hcm-bio:hasSpecies "Mus musculus" ;
   hcm-bio:hasStrain "C57BL/6J" .
 
-ex:behavior-profile-example-hcm a hcm:BehaviorAndPhysiology ;
+ex:behavior-profile-example-hcm rdf:type hcm:BehaviorAndPhysiology ;
   rdfs:label "Example HCM system submission behavior profile" ;
   rdfs:comment "Activity and exploration bouts" ;
   hcm:hasCircadianRhythm ex:circadian-profile-example-hcm .
 
-ex:circadian-profile-example-hcm a hcm:CircadianRhythm ;
+ex:circadian-profile-example-hcm rdf:type hcm:CircadianRhythm ;
   rdfs:label "Nocturnal peak" .
 
-ex:measurement-spec-activity a hcm-env:MeasurementSpecification ;
+ex:measurement-spec-activity rdf:type hcm-env:MeasurementSpecification ;
   rdfs:label "Activity index" ;
   hcm:hasSamplingRate "4 Hz" ;
   hcm-env:hasUnit "count" .
 
-ex:observation-window-example-hcm a hcm:ObservationWindow ;
+ex:observation-window-example-hcm rdf:type hcm:ObservationWindow ;
   rdfs:label "Example HCM system submission observation window" ;
   dcterms:type "Continuous" ;
   hcm:durationHours "48"^^xsd:decimal ;
   hcm:isExtendable "true"^^xsd:boolean .
 
-ex:data-product-example-hcm a hcm:DataProduct ;
+ex:data-product-example-hcm rdf:type hcm:DataProduct ;
   rdfs:label "Example HCM system submission data output" ;
   rdfs:comment "timestamp,cage_id,activity_index" ;
   dcterms:license "CC BY 4.0" ;
@@ -89,7 +90,7 @@ ex:data-product-example-hcm a hcm:DataProduct ;
   hcm:hasSamplingRate "4 Hz" ;
   hcm:hasStoragePath "https://example.org/hcm-system/day-01.csv" .
 
-ex:contributor-jane-doe a schema:Person ;
+ex:contributor-jane-doe rdf:type schema:Person ;
   schema:affiliation "Example Institute" ;
   schema:email "jane@example.org" ;
   schema:name "Jane Doe" ;


### PR DESCRIPTION
[CHECKLIST-CYRIL.md](C:/Users/damie/Documents/GitHub/HCMO/docs/paper/CHECKLIST-CYRIL.md): HermiT and placeholder cleanup reflected; FOOPS added; w3id v2 follow-up tracked; counts now match 44 rows.
[TODO.md](C:/Users/damie/Documents/GitHub/HCMO/docs/paper/TODO.md): added explicit T2b for updating w3id after promoted v2 release.
[contribute/index.html](C:/Users/damie/Documents/GitHub/HCMO/docs/hcm-systems/contribute/index.html): Turtle output now emits explicit rdf:type.
[FORM-FIELD-MAPPING.md](C:/Users/damie/Documents/GitHub/HCMO/docs/hcm-systems/FORM-FIELD-MAPPING.md): documents RDF triple categories: class assertions, object links, literal values.
Added [dvc-tecniplast.ttl](C:/Users/damie/Documents/GitHub/HCMO/examples/dvc-tecniplast.ttl): DVC profile ABox organized as rdf:type, object-property links, and data/annotation literal triples.

### Changed
- Updated paper tracking to reflect completed v2 placeholder cleanup and HermiT reasoner evidence.
- Added FOOPS! FAIR ontology assessment and promoted-v2 w3id update as explicit follow-up tasks.
- Made the HCM systems contribution form emit explicit `rdf:type` triples.
- Added a DVC Tecniplast profile ABox showing class assertions, object-property links, and literal data values.

### Renamed
- None.